### PR TITLE
Interactive Geometry Plotting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(abeille CXX)
 
 option(ABEILLE_USE_OMP "Compile Abeille with OpenMP for shared memory parallelism" ON)
 option(ABEILLE_USE_MPI "Compile Abeille with MPI for distributed memory parallelism" OFF)
+option(ABEILLE_GUI_PLOT "Compile Abeille with support for the GUI plotter" ON)
 
 # Get FetchContent for downloading dependencies
 include(FetchContent)
@@ -55,6 +56,17 @@ set(NDARRAY_INSTALL OFF CACHE BOOL "Install NDArray")
 FetchContent_MakeAvailable(NDArray)
 
 #===============================================================================
+# Get ImApp
+if(ABEILLE_GUI_PLOT)
+  message(STATUS "Downloading ImApp")
+  FetchContent_Declare(ImApp
+    GIT_REPOSITORY https://github.com/HunterBelanger/ImApp.git
+    GIT_TAG        master
+  )
+  FetchContent_MakeAvailable(ImApp)
+endif()
+
+#===============================================================================
 # Get PCG-C++
 message(STATUS "Downloading PCG-C++")
 FetchContent_Declare(PCG_CXX
@@ -100,6 +112,11 @@ if(ABEILLE_USE_MPI)
     target_link_libraries(abeille PUBLIC MPI::MPI_CXX)
     target_compile_definitions(abeille PUBLIC ABEILLE_USE_MPI)
   endif()
+endif()
+
+if(ABEILLE_GUI_PLOT)
+  target_link_libraries(abeille PUBLIC ImApp::ImApp)
+  target_compile_definitions(abeille PUBLIC ABEILLE_GUI_PLOT)
 endif()
 
 #===============================================================================

--- a/include/geometry/cell.hpp
+++ b/include/geometry/cell.hpp
@@ -85,7 +85,7 @@ class Cell {
 
   uint32_t id() const;
 
-  std::string name() const;
+  const std::string& name() const;
 
   const std::vector<std::shared_ptr<Cell>> neighbors() const {
     return neighbors_;

--- a/include/materials/material.hpp
+++ b/include/materials/material.hpp
@@ -81,7 +81,7 @@ class Material : public std::enable_shared_from_this<Material> {
   }
 
   const std::vector<Component>& composition() const { return composition_; }
-  const std::string& get_name() const { return name_; }
+  const std::string& name() const { return name_; }
   uint32_t id() const { return id_; }
   bool fissile() const {
     for (const auto& comp : composition_) {

--- a/include/plotting/gui_plotter.hpp
+++ b/include/plotting/gui_plotter.hpp
@@ -1,0 +1,23 @@
+#ifndef GUI_PLOTTER_H
+#define GUI_PLOTTER_H
+#ifdef ABEILLE_GUI_PLOT
+
+#include <ImApp/imapp.hpp>
+
+namespace plotter {
+  
+  class GuiPlotter : public ImApp::Layer {
+    public:
+      GuiPlotter() = default;
+
+      void render() override final;
+
+    private:
+      void render_viewport();
+      void render_controls();
+  };
+
+}
+
+#endif // ABEILLE_GUI_PLOT
+#endif // GUI_PLOTTER_H

--- a/include/plotting/gui_plotter.hpp
+++ b/include/plotting/gui_plotter.hpp
@@ -29,6 +29,8 @@ namespace plotter {
 
       Direction get_tracking_direction() const;
       Position get_start_position(uint64_t i) const;
+      Direction get_comp_tracking_direction() const;
+      Position get_comp_start_position(uint64_t j) const;
       Position get_pixel_position(uint64_t i, uint64_t j) const;
 
       void render_image();

--- a/include/plotting/gui_plotter.hpp
+++ b/include/plotting/gui_plotter.hpp
@@ -3,60 +3,58 @@
 #ifdef ABEILLE_GUI_PLOT
 
 #include <ImApp/imapp.hpp>
-
 #include <geometry/cell.hpp>
-#include <utils/position.hpp>
-#include <utils/direction.hpp>
-
 #include <map>
 #include <mutex>
+#include <utils/direction.hpp>
+#include <utils/position.hpp>
 
 namespace plotter {
-  
-  class GuiPlotter : public ImApp::Layer {
-    public:
-      GuiPlotter();
 
-      void render() override final;
+class GuiPlotter : public ImApp::Layer {
+ public:
+  GuiPlotter();
 
-    private:
-      void render_viewport();
-      void render_controls();
+  void render() override final;
 
-      ImApp::Pixel get_color(::Cell* cell);
-      ImApp::Pixel get_random_color();
+ private:
+  void render_viewport();
+  void render_controls();
 
-      Direction get_tracking_direction() const;
-      Position get_start_position(uint64_t i) const;
-      Direction get_comp_tracking_direction() const;
-      Position get_comp_start_position(uint64_t j) const;
-      Position get_pixel_position(uint64_t i, uint64_t j) const;
+  ImApp::Pixel get_color(::Cell* cell);
+  ImApp::Pixel get_random_color();
 
-      void render_image();
+  Direction get_tracking_direction() const;
+  Position get_start_position(uint64_t i) const;
+  Direction get_comp_tracking_direction() const;
+  Position get_comp_start_position(uint64_t j) const;
+  Position get_pixel_position(uint64_t i, uint64_t j) const;
 
-      enum Basis : int { XY=0, XZ=1, YZ=2 };
-      enum ColorBy : int { Cell=0, Material=1 };
+  void render_image();
 
-      // Maps for colors from plotter.hpp
-      std::map<uint32_t, ImApp::Pixel> cell_id_to_color;
-      std::map<uint32_t, ImApp::Pixel> material_id_to_color;
-      ImApp::Image image;
-      std::mutex create_color_mutex;
-      int adjust_w_or_h;
-      double height, width; // Width of image in physical space ([cm]).
-      double ox, oy, oz; // Plot origin
-      double mx, my, mz; // Mouse position
-      ::Cell* mcell; // Mouse cell
-      ::Material* mmaterial; // Mouse material
-      double dist_per_pixel;
-      ImApp::Pixel background;
-      ColorBy colorby;
-      Basis basis;
-      bool must_rerender;
-      bool outline_boundaries;
-  };
+  enum Basis : int { XY = 0, XZ = 1, YZ = 2 };
+  enum ColorBy : int { Cell = 0, Material = 1 };
 
-}
+  // Maps for colors from plotter.hpp
+  std::map<uint32_t, ImApp::Pixel> cell_id_to_color;
+  std::map<uint32_t, ImApp::Pixel> material_id_to_color;
+  ImApp::Image image;
+  std::mutex create_color_mutex;
+  int adjust_w_or_h;
+  double height, width;   // Width of image in physical space ([cm]).
+  double ox, oy, oz;      // Plot origin
+  double mx, my, mz;      // Mouse position
+  ::Cell* mcell;          // Mouse cell
+  ::Material* mmaterial;  // Mouse material
+  double dist_per_pixel;
+  ImApp::Pixel background;
+  ColorBy colorby;
+  Basis basis;
+  bool must_rerender;
+  bool outline_boundaries;
+};
 
-#endif // ABEILLE_GUI_PLOT
-#endif // GUI_PLOTTER_H
+}  // namespace plotter
+
+#endif  // ABEILLE_GUI_PLOT
+#endif  // GUI_PLOTTER_H

--- a/include/plotting/gui_plotter.hpp
+++ b/include/plotting/gui_plotter.hpp
@@ -5,7 +5,6 @@
 #include <ImApp/imapp.hpp>
 
 #include <geometry/cell.hpp>
-#include <utils/rng.hpp>
 #include <utils/position.hpp>
 #include <utils/direction.hpp>
 
@@ -51,7 +50,6 @@ namespace plotter {
       ::Material* mmaterial; // Mouse material
       double dist_per_pixel;
       ImApp::Pixel background;
-      pcg32 rng;
       ColorBy colorby;
       Basis basis;
       bool must_rerender;

--- a/include/plotting/gui_plotter.hpp
+++ b/include/plotting/gui_plotter.hpp
@@ -4,17 +4,53 @@
 
 #include <ImApp/imapp.hpp>
 
+#include <geometry/cell.hpp>
+#include <utils/rng.hpp>
+#include <utils/position.hpp>
+#include <utils/direction.hpp>
+
+#include <map>
+#include <mutex>
+
 namespace plotter {
   
   class GuiPlotter : public ImApp::Layer {
     public:
-      GuiPlotter() = default;
+      GuiPlotter();
 
       void render() override final;
 
     private:
       void render_viewport();
       void render_controls();
+
+      ImApp::Pixel get_color(::Cell* cell);
+      ImApp::Pixel get_random_color();
+
+      Direction get_tracking_direction() const;
+      Position get_start_position(uint64_t i) const;
+      Position get_pixel_position(uint64_t i, uint64_t j) const;
+
+      void render_image();
+
+      enum Basis : int { XY=0, XZ=1, YZ=2 };
+      enum ColorBy : int { Cell=0, Material=1 };
+
+      // Maps for colors from plotter.hpp
+      std::map<uint32_t, ImApp::Pixel> cell_id_to_color;
+      std::map<uint32_t, ImApp::Pixel> material_id_to_color;
+      ImApp::Image image;
+      std::mutex create_color_mutex;
+      int adjust_w_or_h;
+      double height, width; // Width of image in physical space ([cm]).
+      double ox, oy, oz;
+      double dist_per_pixel;
+      ImApp::Pixel background;
+      pcg32 rng;
+      ColorBy colorby;
+      Basis basis;
+      bool must_rerender;
+      bool outline_boundaries;
   };
 
 }

--- a/include/plotting/gui_plotter.hpp
+++ b/include/plotting/gui_plotter.hpp
@@ -45,7 +45,10 @@ namespace plotter {
       std::mutex create_color_mutex;
       int adjust_w_or_h;
       double height, width; // Width of image in physical space ([cm]).
-      double ox, oy, oz;
+      double ox, oy, oz; // Plot origin
+      double mx, my, mz; // Mouse position
+      ::Cell* mcell; // Mouse cell
+      ::Material* mmaterial; // Mouse material
       double dist_per_pixel;
       ImApp::Pixel background;
       pcg32 rng;

--- a/include/plotting/pixel.hpp
+++ b/include/plotting/pixel.hpp
@@ -43,12 +43,13 @@ namespace plotter {
 // Pixel class to contain info for a pixel or color definition
 class Pixel {
  public:
-  Pixel(uint8_t i_r = 0xff, uint8_t i_g = 0xff, uint8_t i_b = 0xff): r(i_r), g(i_g), b(i_b) {}
+  Pixel(uint8_t i_r = 0xff, uint8_t i_g = 0xff, uint8_t i_b = 0xff)
+      : r(i_r), g(i_g), b(i_b) {}
   ~Pixel() = default;
 
   uint8_t R() const { return r; }
   uint8_t G() const { return g; }
-  uint8_t B() const { return b;}
+  uint8_t B() const { return b; }
 
   void set_R(uint8_t i_r) { r = i_r; }
   void set_G(uint8_t i_g) { g = i_g; }

--- a/include/plotting/plotter.hpp
+++ b/include/plotting/plotter.hpp
@@ -48,6 +48,11 @@ extern std::map<uint32_t, Pixel> material_id_to_color;
 // Function to begin plotting system
 void plotter(std::string input_fname);
 
+#ifdef ABEILLE_GUI_PLOT
+// Function to start the GUI plotter
+void gui();
+#endif
+
 // Function to begin system to generate a slice plot
 // of a selected geometry file
 void slice_plotter(YAML::Node plot_node);

--- a/include/plotting/plotter.hpp
+++ b/include/plotting/plotter.hpp
@@ -46,11 +46,11 @@ extern std::map<uint32_t, Pixel> cell_id_to_color;
 extern std::map<uint32_t, Pixel> material_id_to_color;
 
 // Function to begin plotting system
-void plotter(std::string input_fname);
+void plotter(const std::string& input_fname);
 
 #ifdef ABEILLE_GUI_PLOT
 // Function to start the GUI plotter
-void gui();
+void gui(const std::string& input_fname);
 #endif
 
 // Function to begin system to generate a slice plot

--- a/include/plotting/slice_plot.hpp
+++ b/include/plotting/slice_plot.hpp
@@ -41,7 +41,6 @@
 #include <string>
 #include <utils/direction.hpp>
 #include <utils/position.hpp>
-#include <utils/rng.hpp>
 #include <vector>
 
 namespace plotter {
@@ -71,7 +70,6 @@ class SlicePlot {
   Pixel background_;
   std::vector<Pixel> image_matrix;  // Row-Major order
   double width_, height_;
-  pcg32 rng;
   std::mutex create_color_mutex;
 
   Position get_pixel_position(uint64_t i, uint64_t j) const;

--- a/sourcelist.cmake
+++ b/sourcelist.cmake
@@ -42,6 +42,7 @@ set(ABEILLE_SOURCE_FILES ${ABEILLE_SOURCE_FILES}
   src/simulation.cpp
   src/slice_plot.cpp
   src/plotter.cpp
+  src/gui_plotter.cpp
   src/hex_lattice.cpp
   src/rect_lattice.cpp
   src/lattice.cpp

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -34,6 +34,9 @@
 #include <geometry/cell.hpp>
 #include <utils/constants.hpp>
 #include <utils/error.hpp>
+#include <utils/settings.hpp>
+#include <utils/rng.hpp>
+#include <plotting/plotter.hpp>
 
 Cell::Cell(std::vector<int32_t> i_rpn, std::shared_ptr<Material> material,
            uint32_t i_id, std::string i_name)
@@ -321,5 +324,12 @@ void make_cell(YAML::Node cell_node) {
   } else {
     cell_id_to_indx[cell_pntr->id()] = geometry::cells.size();
     geometry::cells.push_back(cell_pntr);
+
+    // Generate a random color for the cell
+    uint8_t r = static_cast<uint8_t>(255.0 * RNG::rand(settings::rng));
+    uint8_t g = static_cast<uint8_t>(255.0 * RNG::rand(settings::rng));
+    uint8_t b = static_cast<uint8_t>(255.0 * RNG::rand(settings::rng));
+    plotter::Pixel cell_color(r, g, b);
+    plotter::cell_id_to_color[cell_pntr->id()] = cell_color;
   }
 }

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -156,7 +156,7 @@ bool Cell::is_inside_complex(const Position& r, const Direction& u,
 
 uint32_t Cell::id() const { return id_; }
 
-std::string Cell::name() const { return name_; }
+const std::string& Cell::name() const { return name_; }
 
 //============================================================================
 // Non-Member functions

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -32,11 +32,11 @@
  * termes.
  *============================================================================*/
 #include <geometry/cell.hpp>
+#include <plotting/plotter.hpp>
 #include <utils/constants.hpp>
 #include <utils/error.hpp>
-#include <utils/settings.hpp>
 #include <utils/rng.hpp>
-#include <plotting/plotter.hpp>
+#include <utils/settings.hpp>
 
 Cell::Cell(std::vector<int32_t> i_rpn, std::shared_ptr<Material> material,
            uint32_t i_id, std::string i_name)

--- a/src/gui_plotter.cpp
+++ b/src/gui_plotter.cpp
@@ -5,6 +5,8 @@
 #include <utils/error.hpp>
 #include <simulation/tracker.hpp>
 
+#include <filesystem>
+
 namespace plotter {
 
 // Maps for colors from plotter.hpp
@@ -42,16 +44,6 @@ GuiPlotter::GuiPlotter():
 }
 
 void GuiPlotter::render() {
-  if (ImGui::BeginMainMenuBar()) {
-    if (ImGui::BeginMenu("Options")) {
-      if (ImGui::BeginMenu("Save")) {
-        ImGui::EndMenu();
-      }
-      ImGui::EndMenu();
-    }
-    ImGui::EndMainMenuBar();
-  }
-
   // We put a Dockspace over the entire viewport.
   ImGui::DockSpaceOverViewport(ImGui::GetMainViewport());
 
@@ -207,11 +199,11 @@ void GuiPlotter::render_viewport() {
                   static_cast<float>(color.a()) / 255.f);
 
     if (colorby == ColorBy::Material) {
-      ImGui::Text("Cell ID: %i", mcell->id());
-      ImGui::Text("Cell Name: %s", mcell->name().data());
-    } else {
       ImGui::Text("Material ID: %i", mmaterial->id());
       ImGui::Text("Material Name: %s", mmaterial->name().data()); 
+    } else {
+      ImGui::Text("Cell ID: %i", mcell->id());
+      ImGui::Text("Cell Name: %s", mcell->name().data());
     }
 
     if (ImGui::ColorEdit3("", reinterpret_cast<float*>(&fcolor))) {
@@ -331,6 +323,30 @@ void GuiPlotter::render_controls() {
         must_rerender = true;
       }
     }
+  }
+
+  // Save Image
+  ImGui::Separator();
+  if (ImGui::Button("Save Plot")) ImGui::OpenPopup("Save Plot");
+  if (ImGui::BeginPopup("Save Plot")) {
+    static char fn_str[500] = "";  
+
+    ImGui::InputTextWithHint("", "Enter File Name (i.e. reactor)", fn_str, IM_ARRAYSIZE(fn_str));
+
+    if (ImGui::Button("Save JPG")) {
+      std::filesystem::path fname(fn_str);
+      fname += ".jpg";
+      image.save_jpg(fname);
+      ImGui::CloseCurrentPopup();
+    } ImGui::SameLine();
+    if (ImGui::Button("Save PNG")) {
+      std::filesystem::path fname(fn_str);
+      fname += ".png";
+      image.save_png(fname);
+      ImGui::CloseCurrentPopup();
+    }
+
+    ImGui::EndPopup();
   }
 
   ImGui::End();

--- a/src/gui_plotter.cpp
+++ b/src/gui_plotter.cpp
@@ -1,0 +1,39 @@
+#ifdef ABEILLE_GUI_PLOT
+
+#include <plotting/gui_plotter.hpp>
+
+namespace plotter {
+
+void GuiPlotter::render() {
+  if (ImGui::BeginMainMenuBar()) {
+    if (ImGui::BeginMenu("Options")) {
+      if (ImGui::BeginMenu("Save")) {
+        ImGui::EndMenu();
+      }
+      ImGui::EndMenu();
+    }
+    ImGui::EndMainMenuBar();
+  }
+
+  // We put a Dockspace over the entire viewport.
+  ImGui::DockSpaceOverViewport(ImGui::GetMainViewport());
+
+  this->render_controls();
+  this->render_viewport();
+}
+
+void GuiPlotter::render_viewport() {
+  ImGui::SetNextWindowSize({500, 500}, ImGuiCond_Once);
+  ImGui::Begin("Viewport");
+  ImGui::End();
+}
+
+void GuiPlotter::render_controls() {
+  ImGui::SetNextWindowSize({500, 500}, ImGuiCond_Once);
+  ImGui::Begin("Controls");
+  ImGui::End();
+}
+  
+}
+
+#endif // ABEILLE_GUI_PLOT

--- a/src/gui_plotter.cpp
+++ b/src/gui_plotter.cpp
@@ -3,6 +3,8 @@
 #include <plotting/gui_plotter.hpp>
 #include <plotting/pixel.hpp>
 #include <utils/error.hpp>
+#include <utils/settings.hpp>
+#include <utils/rng.hpp>
 #include <simulation/tracker.hpp>
 
 #include <filesystem>
@@ -24,7 +26,6 @@ GuiPlotter::GuiPlotter():
  mx(0.), my(0.), mz(0.),
  mcell(nullptr), mmaterial(nullptr),
  background(),
- rng(),
  colorby(ColorBy::Material),
  basis(Basis::XY),
  must_rerender(true),
@@ -468,9 +469,9 @@ void GuiPlotter::render_image() {
 }
 
 ImApp::Pixel GuiPlotter::get_random_color() {
-  uint8_t r = static_cast<uint8_t>(255.0 * RNG::rand(rng));
-  uint8_t g = static_cast<uint8_t>(255.0 * RNG::rand(rng));
-  uint8_t b = static_cast<uint8_t>(255.0 * RNG::rand(rng));
+  uint8_t r = static_cast<uint8_t>(255.0 * RNG::rand(settings::rng));
+  uint8_t g = static_cast<uint8_t>(255.0 * RNG::rand(settings::rng));
+  uint8_t b = static_cast<uint8_t>(255.0 * RNG::rand(settings::rng));
 
   return ImApp::Pixel(r, g, b);
 }

--- a/src/gui_plotter.cpp
+++ b/src/gui_plotter.cpp
@@ -101,9 +101,9 @@ void GuiPlotter::render_controls() {
   // Origin
   ImGui::Separator();
   ImGui::Text("Plot Origin");
-  if(ImGui::InputDouble("X [cm] :", &ox, 0., 0., "%E")) must_rerender = true;
-  if(ImGui::InputDouble("Y [cm] :", &oy, 0., 0., "%E")) must_rerender = true;
-  if(ImGui::InputDouble("Z [cm] :", &oz, 0., 0., "%E")) must_rerender = true;
+  if(ImGui::InputDouble("X [cm]", &ox, 0., 0.)) must_rerender = true;
+  if(ImGui::InputDouble("Y [cm]", &oy, 0., 0.)) must_rerender = true;
+  if(ImGui::InputDouble("Z [cm]", &oz, 0., 0.)) must_rerender = true;
 
   // Physical Dimensions of plot
   ImGui::Separator();
@@ -111,7 +111,7 @@ void GuiPlotter::render_controls() {
   ImGui::RadioButton("Width", &adjust_w_or_h, 0); ImGui::SameLine();
   ImGui::RadioButton("Height", &adjust_w_or_h, 1);
   if (adjust_w_or_h == 0) {
-    if (ImGui::InputDouble("Width [cm] :", &width, 0., 0., "%E")) {
+    if (ImGui::InputDouble("Width [cm]", &width, 0., 0.)) {
       must_rerender = true;
 
       if (width < 1.E-6) width = 1.E-6;
@@ -121,7 +121,7 @@ void GuiPlotter::render_controls() {
       height = static_cast<double>(image.height()) * dist_per_pixel;
     }
   } else if(adjust_w_or_h == 1) {
-    if(ImGui::InputDouble("Height [cm] :", &height, 0., 0., "%E")) {
+    if(ImGui::InputDouble("Height [cm]", &height, 0., 0.)) {
       must_rerender = true; 
       
       if (height < 1.E-6) height = 1.E-6;
@@ -131,7 +131,7 @@ void GuiPlotter::render_controls() {
       width = static_cast<double>(image.width()) * dist_per_pixel;
     }
   }
-  ImGui::Text("Width [cm]: %E, Height [cm]: %E", width, height);
+  ImGui::Text("Width [cm]: %f, Height [cm]: %f", width, height);
 
   // Slice Basis
   ImGui::Separator();

--- a/src/gui_plotter.cpp
+++ b/src/gui_plotter.cpp
@@ -1,8 +1,43 @@
 #ifdef ABEILLE_GUI_PLOT
 
 #include <plotting/gui_plotter.hpp>
+#include <plotting/pixel.hpp>
+#include <utils/error.hpp>
+#include <simulation/tracker.hpp>
 
 namespace plotter {
+
+// Maps for colors from plotter.hpp
+extern std::map<uint32_t, Pixel> cell_id_to_color;
+extern std::map<uint32_t, Pixel> material_id_to_color;
+
+GuiPlotter::GuiPlotter():
+ cell_id_to_color(),
+ material_id_to_color(),
+ image(500, 500),
+ create_color_mutex(),
+ height(10.),
+ width(10.),
+ ox(0.), oy(0.), oz(0.),
+ background(),
+ rng(),
+ colorby(ColorBy::Material),
+ basis(Basis::XY),
+ must_rerender(true),
+ outline_boundaries(true) {
+  // First, fill locatl color maps with the outer color maps
+  for (const auto& color : plotter::cell_id_to_color) {
+    const uint32_t& id = color.first;
+    const Pixel& p = color.second;
+    this->cell_id_to_color[id] = ImApp::Pixel(p.R(), p.G(), p.B()); 
+  }
+
+  for (const auto& color : plotter::material_id_to_color) {
+    const uint32_t& id = color.first;
+    const Pixel& p = color.second;
+    this->material_id_to_color[id] = ImApp::Pixel(p.R(), p.G(), p.B()); 
+  }
+}
 
 void GuiPlotter::render() {
   if (ImGui::BeginMainMenuBar()) {
@@ -18,20 +53,337 @@ void GuiPlotter::render() {
   // We put a Dockspace over the entire viewport.
   ImGui::DockSpaceOverViewport(ImGui::GetMainViewport());
 
-  this->render_controls();
   this->render_viewport();
+  this->render_controls();
 }
 
 void GuiPlotter::render_viewport() {
   ImGui::SetNextWindowSize({500, 500}, ImGuiCond_Once);
   ImGui::Begin("Viewport");
+  
+  // First, get the window size. If the size doesn't match the current
+  // image size, we must set must_rerender to true. 
+  std::uint32_t wwidth = static_cast<std::uint32_t>(ImGui::GetWindowWidth());
+  std::uint32_t wheight = static_cast<std::uint32_t>(ImGui::GetWindowHeight());
+  if ((wwidth != image.width()) ||
+      (wheight != image.height())) {
+    image.resize(wheight, wwidth);
+
+    dist_per_pixel = width / static_cast<double>(image.width());
+    height = static_cast<double>(image.height()) * dist_per_pixel;
+
+    must_rerender = true;
+  }
+
+  // If we window must be rerendered, we do that now
+  if (must_rerender) {
+    this->render_image(); 
+    must_rerender = false;
+
+    // Now we need to send the image to the GPU.
+    image.send_to_gpu();
+  }
+
+  // Now we need to add the image to the window
+  void* texture_id = reinterpret_cast<void*>(
+      static_cast<intptr_t>(image.ogl_texture_id().value()));
+  ImGui::Image(texture_id, ImVec2(static_cast<float>(image.width()),
+        static_cast<float>(image.height())));
+
   ImGui::End();
 }
 
 void GuiPlotter::render_controls() {
   ImGui::SetNextWindowSize({500, 500}, ImGuiCond_Once);
   ImGui::Begin("Controls");
+
+  // Origin
+  ImGui::Separator();
+  ImGui::Text("Plot Origin");
+  if(ImGui::InputDouble("X [cm] :", &ox, 0., 0., "%E")) must_rerender = true;
+  if(ImGui::InputDouble("Y [cm] :", &oy, 0., 0., "%E")) must_rerender = true;
+  if(ImGui::InputDouble("Z [cm] :", &oz, 0., 0., "%E")) must_rerender = true;
+
+  // Physical Dimensions of plot
+  ImGui::Separator();
+  ImGui::Text("Width/Height");
+  ImGui::RadioButton("Width", &adjust_w_or_h, 0); ImGui::SameLine();
+  ImGui::RadioButton("Height", &adjust_w_or_h, 1);
+  if (adjust_w_or_h == 0) {
+    if (ImGui::InputDouble("Width [cm] :", &width, 1.E-6, 1.E32, "%E")) {
+      must_rerender = true;
+
+      // Must recalculate height
+      dist_per_pixel = width / static_cast<double>(image.width());
+      height = static_cast<double>(image.height()) * dist_per_pixel;
+    }
+  } else if(adjust_w_or_h == 1) {
+    if(ImGui::InputDouble("Height [cm] :", &height, 1.E-6, 1.E32, "%E")) {
+      must_rerender = true; 
+      
+      // Must recalculate width
+      dist_per_pixel = height / static_cast<double>(image.height());
+      width = static_cast<double>(image.width()) * dist_per_pixel;
+    }
+  }
+  ImGui::Text("Width [cm]: %E, Height [cm]: %E", width, height);
+
+  // Slice Basis
+  ImGui::Separator();
+  ImGui::Text("Slice Basis");
+  if(ImGui::RadioButton("XY", reinterpret_cast<int*>(&basis), Basis::XY)) must_rerender = true;
+  ImGui::SameLine();
+  if(ImGui::RadioButton("XZ", reinterpret_cast<int*>(&basis), Basis::XZ)) must_rerender = true;
+  ImGui::SameLine();
+  if(ImGui::RadioButton("YZ", reinterpret_cast<int*>(&basis), Basis::YZ)) must_rerender = true;
+
+  // Color Method
+  ImGui::Separator();
+  ImGui::Text("Coloring");
+  if(ImGui::RadioButton("Cell", reinterpret_cast<int*>(&colorby), ColorBy::Cell)) must_rerender = true;
+  ImGui::SameLine();
+  if(ImGui::RadioButton("Material", reinterpret_cast<int*>(&colorby), ColorBy::Material)) must_rerender = true;
+
+  if (ImGui::Checkbox("Mark Boundaries", &outline_boundaries)) must_rerender = true;
+
   ImGui::End();
+}
+
+void GuiPlotter::render_image() {
+  // Get the tracking direction
+  const Direction u = this->get_tracking_direction();
+
+// Go through each pixel
+#ifdef _OPENMP
+#pragma omp parallel for schedule(dynamic)
+#endif
+  for (uint32_t i = 0; i < image.height(); i++) {
+    Position strt = get_start_position(i);
+
+    // Initalize the tracker
+    Tracker trkr(strt, u);
+    ::Cell* cell = trkr.cell();
+    ImApp::Pixel pixel_color = this->get_color(cell);
+
+    uint32_t j = 0;
+    while (j < image.width()) {
+      // Get the boundary
+      auto bound = trkr.get_nearest_boundary();
+
+      // Get the number of pixels till the boundary
+      const double pixels_to_bound = bound.distance / dist_per_pixel;
+      uint32_t npixels = static_cast<uint32_t>(std::round(pixels_to_bound));
+      if (npixels > (image.width() - j) || bound.distance == INF) {
+        npixels = image.width() - j;
+      }
+      const double npixels_dist = static_cast<double>(npixels) * dist_per_pixel;
+
+      // Set all pixels
+      for (uint32_t p = 0; p < npixels; p++) {
+        if (j >= image.width()) break;
+        if (outline_boundaries && npixels > 0 &&
+            (p == npixels-1 || j == image.width()-1)) {
+          image.at(i, j) = ImApp::Pixel(0, 0, 0);
+        } else {
+          image.at(i, j) = pixel_color;
+        }
+        j++;
+      }
+      if (j >= image.width()) break;
+
+      // Cross boundary, update cell, and get new pixel
+      if (pixels_to_bound - static_cast<double>(npixels) < 0.5) {
+        trkr.move(npixels_dist + dist_per_pixel);
+      } else {
+        trkr.move(npixels_dist);
+      }
+      trkr.restart_get_current();
+      cell = trkr.cell();
+      pixel_color = this->get_color(cell);
+      if (pixels_to_bound - static_cast<double>(npixels) < 0.5) {
+        if (j >= image.width()) break;
+        image.at(i, j) = pixel_color;
+        j++;
+      }
+    }  // while j < plot_width_
+  }    // For i which is parallel
+}
+
+ImApp::Pixel GuiPlotter::get_random_color() {
+  uint8_t r = static_cast<uint8_t>(255.0 * RNG::rand(rng));
+  uint8_t g = static_cast<uint8_t>(255.0 * RNG::rand(rng));
+  uint8_t b = static_cast<uint8_t>(255.0 * RNG::rand(rng));
+
+  return ImApp::Pixel(r, g, b);
+}
+
+ImApp::Pixel GuiPlotter::get_color(::Cell* cell) {
+  ImApp::Pixel pixel_color = background;
+  // If pointer isn't nullpntr, get pixel
+  if (cell != nullptr) {
+    if (colorby == ColorBy::Cell) {
+      // Do same check twice with mutex to make thread safe
+      if (cell_id_to_color.find(cell->id()) == cell_id_to_color.end()) {
+        // Check if cell id is in id_to_pixel
+        create_color_mutex.lock();
+        if (cell_id_to_color.find(cell->id()) == cell_id_to_color.end()) {
+          // Get new random color for id
+          cell_id_to_color[cell->id()] = get_random_color();
+        }
+        create_color_mutex.unlock();
+      }
+      pixel_color = cell_id_to_color[cell->id()];
+    } else {
+      // Color by material
+      const ::Material* material = cell->material();
+      // Do same check twice with mutex to make thread safe
+      if (material_id_to_color.find(material->id()) ==
+          material_id_to_color.end()) {
+        // Check if cell id is in id_to_pixel
+        create_color_mutex.lock();
+        if (material_id_to_color.find(material->id()) ==
+            material_id_to_color.end()) {
+          // Get new random color for id
+          material_id_to_color[material->id()] = get_random_color();
+        }
+        create_color_mutex.unlock();
+      }
+      pixel_color = material_id_to_color[material->id()];
+    }
+  }
+  return pixel_color;
+}
+
+Direction GuiPlotter::get_tracking_direction() const {
+  switch (basis) {
+    case Basis::XY:
+      return Direction(0., 1., 0.);
+      break;
+    case Basis::YZ:
+      return Direction(0., 0., 1.);
+      break;
+    case Basis::XZ:
+      return Direction(0., 0., 1.);
+      break;
+  }
+
+  // NEVER GETS HERE
+  return Direction(1., 0., 0.);
+}
+
+Position GuiPlotter::get_start_position(uint64_t i) const {
+  // Make sure indicies are valid. i goes down so is height, j goes
+  // across so is width
+  if (i >= image.height()) {
+    std::string mssg = "Trying to deffine invalid pixel for plot.";
+    fatal_error(mssg, __FILE__, __LINE__);
+  }
+
+  if (basis == Basis::XY) {
+    // x is i going down, j is y going across
+    // First get height and width of a pixel
+    const double dx = height / static_cast<double>(image.height());
+
+    // Get upper corner off plot
+    const double x_low = ox - (0.5 * height);
+    const double y_low = oy - (0.5 * width);
+
+    // Get coordinate of pixel
+    const double x = (static_cast<double>(i) + 0.5) * dx + x_low;
+    const double y = y_low;
+
+    // Return coordinate
+    return {x, y, oz};
+  } else if (basis == Basis::YZ) {
+    // y is i going down, j is z going across
+    // First get height and width of a pixel
+    const double dy = height / static_cast<double>(image.height());
+
+    // Get upper corner off plot
+    const double y_low = oy - (0.5 * height);
+    const double z_low = oz - (0.5 * width);
+
+    // Get coordinate of pixel
+    const double y = (static_cast<double>(i) + 0.5) * dy + y_low;
+    const double z = z_low;
+
+    // Return coordinate
+    return {ox, y, z};
+  } else {
+    // x is i going down, j is z going across
+    // First get height and width of a pixel
+    const double dx = height / static_cast<double>(image.height());
+
+    // Get upper corner off plot
+    const double x_low = ox - (0.5 * height);
+    const double z_low = oz - (0.5 * width);
+
+    // Get coordinate of pixel
+    const double x = (static_cast<double>(i) + 0.5) * dx + x_low;
+    const double z = z_low;
+
+    // Return coordinate
+    return {x, oy, z};
+  }
+}
+
+Position GuiPlotter::get_pixel_position(uint64_t i, uint64_t j) const {
+  // Make sure indicies are valid. i goes down so is height, j goes
+  // across so is width
+  if (i >= image.height() || j >= image.width()) {
+    std::string mssg = "Trying to deffine invalid pixel for plot.";
+    fatal_error(mssg, __FILE__, __LINE__);
+  }
+
+  if (basis == Basis::XY) {
+    // x is i going down, j is y going across
+    // First get height and width of a pixel
+    const double dx = height / static_cast<double>(image.height());
+    const double dy = width / static_cast<double>(image.width());
+
+    // Get upper corner off plot
+    const double x_low = ox - (0.5 * height);
+    const double y_low = oy - (0.5 * width);
+
+    // Get coordinate of pixel
+    const double x = (static_cast<double>(i) + 0.5) * dx + x_low;
+    const double y = (static_cast<double>(j) + 0.5) * dy + y_low;
+
+    // Return coordinate
+    return {x, y, oz};
+  } else if (basis == Basis::YZ) {
+    // y is i going down, j is z going across
+    // First get height and width of a pixel
+    const double dy = height / static_cast<double>(image.height());
+    const double dz = width / static_cast<double>(image.width());
+
+    // Get upper corner off plot
+    const double y_low = oy - (0.5 * height);
+    const double z_low = oz - (0.5 * width);
+
+    // Get coordinate of pixel
+    const double y = (static_cast<double>(i) + 0.5) * dy + y_low;
+    const double z = (static_cast<double>(j) + 0.5) * dz + z_low;
+
+    // Return coordinate
+    return {ox, y, z};
+  } else {
+    // x is i going down, j is z going across
+    // First get height and width of a pixel
+    const double dx = height / static_cast<double>(image.height());
+    const double dz = width / static_cast<double>(image.width());
+
+    // Get upper corner off plot
+    const double x_low = ox - (0.5 * height);
+    const double z_low = oz - (0.5 * width);
+
+    // Get coordinate of pixel
+    const double x = (static_cast<double>(i) + 0.5) * dx + x_low;
+    const double z = (static_cast<double>(j) + 0.5) * dz + z_low;
+
+    // Return coordinate
+    return {x, oy, z};
+  }
 }
   
 }

--- a/src/header.cpp
+++ b/src/header.cpp
@@ -8,8 +8,7 @@
  * respectant les principes de diffusion des logiciels libres. Vous pouvez
  * utiliser, modifier et/ou redistribuer ce programme sous les conditions
  * de la licence CeCILL telle que diffusée par le CEA, le CNRS et l'INRIA
- * sur le site "http://www.cecill.info".
- *
+ * sur le site "http://www.cecill.info".  *
  * En contrepartie de l'accessibilité au code source et des droits de copie,
  * de modification et de redistribution accordés par cette licence, il n'est
  * offert aux utilisateurs qu'une garantie limitée.  Pour les mêmes raisons,
@@ -81,7 +80,7 @@ const std::string help =
 #else
     "   abeille (--input FILE) [--output FILE]\n"
 #endif
-    "   abeille (--input FILE --plot) [--threads NUM]\n"
+    "   abeille (--input FILE) (--gui-plot | --plot) [--threads NUM]\n"
     "   abeille (-h | --help)\n"
     "   abeille (-v | --version)\n\n"
 
@@ -93,6 +92,9 @@ const std::string help =
     "   -t --threads NUM  Set number of OpenMP threads\n"
 #endif
     "   -o --output FILE  Set output file\n"
+#ifdef ABEILLE_GUI_PLOT
+    "   -g --gui-plot     Interactive GUI plotter\n"
+#endif
     "   -p --plot         Generate plots from input file\n";
 
 const std::string version_string = " Abeille " ABEILLE_VERSION_STRING

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,7 +109,11 @@ int main(int argc, char** argv) {
   Output::set_output_filename(output_filename);
   mpi::synchronize();
 
+#ifdef ABEILLE_GUI_PLOT
+  if (args["--gui-plot"].asBool() || args["--plot"].asBool()) {
+#else
   if (args["--plot"].asBool()) {
+#endif
     // If using OpenMP, get number of threads requested
 #ifdef _OPENMP
     int num_omp_threads;
@@ -138,7 +142,15 @@ int main(int argc, char** argv) {
 
       try {
         // Begin plotting system
+#ifdef ABEILLE_GUI_PLOT
+        if (args["--gui-plot"].asBool()) {
+          plotter::gui();
+        } else {
+          plotter::plotter(input_fname);
+        }
+#else
         plotter::plotter(input_fname);
+#endif
       } catch (const std::runtime_error& err) {
         std::string mssg = err.what();
         Output::instance()->write(" FATAL ERROR: " + mssg + ".\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,7 +144,7 @@ int main(int argc, char** argv) {
         // Begin plotting system
 #ifdef ABEILLE_GUI_PLOT
         if (args["--gui-plot"].asBool()) {
-          plotter::gui();
+          plotter::gui(input_fname);
         } else {
           plotter::plotter(input_fname);
         }

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -33,12 +33,12 @@
  *============================================================================*/
 #include <materials/material.hpp>
 #include <materials/mg_nuclide.hpp>
+#include <memory>
 #include <plotting/slice_plot.hpp>
 #include <utils/error.hpp>
 #include <utils/output.hpp>
-#include <utils/settings.hpp>
 #include <utils/rng.hpp>
-#include <memory>
+#include <utils/settings.hpp>
 #include <vector>
 
 std::map<uint32_t, std::shared_ptr<Material>> materials;

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -44,7 +44,7 @@ std::map<uint32_t, std::shared_ptr<Material>> materials;
 
 void fill_mg_material(const YAML::Node& mat,
                       std::shared_ptr<Material> material) {
-  std::string read_mssg = " Reading material " + material->get_name() + ".\n";
+  std::string read_mssg = " Reading material " + material->name() + ".\n";
   Output::instance()->write(read_mssg);
 
   // Can add nuclide to material

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -33,11 +33,12 @@
  *============================================================================*/
 #include <materials/material.hpp>
 #include <materials/mg_nuclide.hpp>
-#include <memory>
 #include <plotting/slice_plot.hpp>
 #include <utils/error.hpp>
 #include <utils/output.hpp>
 #include <utils/settings.hpp>
+#include <utils/rng.hpp>
+#include <memory>
 #include <vector>
 
 std::map<uint32_t, std::shared_ptr<Material>> materials;
@@ -84,8 +85,14 @@ void make_material(const YAML::Node& mat, bool plotting_mode) {
     uint8_t G = mat["color"][1].as<uint8_t>();
     uint8_t B = mat["color"][2].as<uint8_t>();
     mat_color = plotter::Pixel(R, G, B);
-    plotter::material_id_to_color[material->id()] = mat_color;
+  } else {
+    // Generate a random color for the material
+    uint8_t r = static_cast<uint8_t>(255.0 * RNG::rand(settings::rng));
+    uint8_t g = static_cast<uint8_t>(255.0 * RNG::rand(settings::rng));
+    uint8_t b = static_cast<uint8_t>(255.0 * RNG::rand(settings::rng));
+    mat_color = plotter::Pixel(r, g, b);
   }
+  plotter::material_id_to_color[material->id()] = mat_color;
 
   if (!plotting_mode) {
     if (settings::energy_mode == settings::EnergyMode::MG) {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -138,7 +138,7 @@ void print_header() {
   info += " MPI Ranks           : " + std::to_string(mpi::size) + "\n";
 #endif
 
-  info += " Abeille Git Hash   : " ABEILLE_GIT_HASH "\n";
+  info += " Abeille Git Hash    : " ABEILLE_GIT_HASH "\n";
 
   output->write(info);
 }

--- a/src/plotter.cpp
+++ b/src/plotter.cpp
@@ -207,9 +207,9 @@ void gui(const std::string& input_fname) {
 
   try {
     ImApp::App guiplotter(1920, 1080, "Abeille Geometry Plotter");
-    // Viewports don't always work on Linux, and cant lead to a segfault.
-    // Do to this, I don't have it enabled here.
-    //guiplotter.enable_viewports();
+    // Viewports don't always work well on Linux.
+    // Might want to disable this at some point.
+    guiplotter.enable_viewports();
     guiplotter.enable_docking();
     guiplotter.push_layer(std::make_unique<GuiPlotter>());
     // TODO Add Icon

--- a/src/plotter.cpp
+++ b/src/plotter.cpp
@@ -216,7 +216,7 @@ void gui(const std::string& input_fname) {
     guiplotter.run();
   } catch (std::exception& error) {
     Output::instance()->write_error(error.what());
-    std::exit(1); 
+    std::exit(1);
   }
 }
 #endif

--- a/src/plotter.cpp
+++ b/src/plotter.cpp
@@ -185,4 +185,12 @@ void slice_plotter(YAML::Node plot_node) {
   plot.write();
 }
 
+#ifdef ABEILLE_GUI_PLOT
+void gui() {
+  Output::instance()->write(" Staring GUI plotter...\n");
+
+  // TODO
+}
+#endif
+
 }  // namespace plotter

--- a/src/plotter.cpp
+++ b/src/plotter.cpp
@@ -46,7 +46,7 @@ namespace plotter {
 std::map<uint32_t, Pixel> cell_id_to_color;
 std::map<uint32_t, Pixel> material_id_to_color;
 
-void plotter(std::string input_fname) {
+void plotter(const std::string& input_fname) {
   // Get output pointer
   std::shared_ptr<Output> out = Output::instance();
   out->write(" Starting plotting engine...\n");
@@ -191,8 +191,19 @@ void slice_plotter(YAML::Node plot_node) {
 }
 
 #ifdef ABEILLE_GUI_PLOT
-void gui() {
-  Output::instance()->write(" Staring GUI plotter...\n");
+void gui(const std::string& input_fname) {
+  // Get output pointer
+  std::shared_ptr<Output> out = Output::instance();
+  out->write(" Starting GUI plotter...\n");
+
+  // Open the YAML node for input file
+  YAML::Node input = YAML::LoadFile(input_fname);
+
+  // Load materials in plotting_mode = true
+  make_materials(input, true);
+
+  // Load geometry portions of input
+  make_geometry(input);
 
   try {
     ImApp::App guiplotter(1920, 1080, "Abeille Geometry Plotter");

--- a/src/plotter.cpp
+++ b/src/plotter.cpp
@@ -36,6 +36,11 @@
 #include <utils/output.hpp>
 #include <utils/parser.hpp>
 
+#ifdef ABEILLE_GUI_PLOT
+#include <ImApp/imapp.hpp>
+#include <plotting/gui_plotter.hpp>
+#endif
+
 namespace plotter {
 // Maps for plotting colors
 std::map<uint32_t, Pixel> cell_id_to_color;
@@ -189,7 +194,19 @@ void slice_plotter(YAML::Node plot_node) {
 void gui() {
   Output::instance()->write(" Staring GUI plotter...\n");
 
-  // TODO
+  try {
+    ImApp::App guiplotter(1920, 1080, "Abeille Geometry Plotter");
+    // Viewports don't always work on Linux, and cant lead to a segfault.
+    // Do to this, I don't have it enabled here.
+    //guiplotter.enable_viewports();
+    guiplotter.enable_docking();
+    guiplotter.push_layer(std::make_unique<GuiPlotter>());
+    // TODO Add Icon
+    guiplotter.run();
+  } catch (std::exception& error) {
+    Output::instance()->write_error(error.what());
+    std::exit(1); 
+  }
 }
 #endif
 

--- a/src/rect_lattice.cpp
+++ b/src/rect_lattice.cpp
@@ -215,21 +215,21 @@ double RectLattice::distance_to_tile_boundary(
       tile[1] >= static_cast<int32_t>(Ny) ||
       tile[2] > static_cast<int32_t>(Nz)) {
     double dmin = (Xl - r_local.x()) / u.x();
-    double dmax = (Xl+(Nx*Px) - r_local.x()) / u.x();
+    double dmax = (Xl + (Nx * Px) - r_local.x()) / u.x();
     if (dmin > dmax) std::swap(dmin, dmax);
 
     double dymin = (Yl - r_local.y()) / u.y();
-    double dymax = (Yl+(Ny*Py) - r_local.y()) / u.y();
+    double dymax = (Yl + (Ny * Py) - r_local.y()) / u.y();
     if (dymin > dymax) std::swap(dymin, dymax);
 
     if ((dmin > dymax) || (dymin > dmax)) return INF;
 
     if (dymin > dmin) dmin = dymin;
 
-    if (dymax < dmax) dmax = dymax; 
+    if (dymax < dmax) dmax = dymax;
 
     double dzmin = (Zl - r_local.z()) / u.z();
-    double dzmax = (Zl+(Nz*Pz) - r_local.z()) / u.z();
+    double dzmax = (Zl + (Nz * Pz) - r_local.z()) / u.z();
     if (dzmin > dzmax) std::swap(dzmin, dzmax);
 
     if ((dmin > dzmax) || (dzmin > dmax)) return INF;
@@ -270,7 +270,7 @@ double RectLattice::distance_to_tile_boundary(
   double d_yh = diff_yh / u.y();
   double d_zl = diff_zl / u.z();
   double d_zh = diff_zh / u.z();
-  
+
   if (d_xl > 0. && d_xl < dist && std::abs(diff_xl) > 100 * SURFACE_COINCIDENT)
     dist = d_xl;
   if (d_xh > 0. && d_xh < dist && std::abs(diff_xh) > 100 * SURFACE_COINCIDENT)

--- a/src/rect_lattice.cpp
+++ b/src/rect_lattice.cpp
@@ -208,6 +208,46 @@ std::array<int32_t, 3> RectLattice::get_tile(Position r, Direction u) const {
 
 double RectLattice::distance_to_tile_boundary(
     Position r_local, Direction u, std::array<int32_t, 3> tile) const {
+  // Check if we are inside the lattice, or outside. If we are outside,
+  // we need to do something different.
+  if (tile[0] < 0 || tile[1] < 0 || tile[2] < 0 ||
+      tile[0] >= static_cast<int32_t>(Nx) ||
+      tile[1] >= static_cast<int32_t>(Ny) ||
+      tile[2] > static_cast<int32_t>(Nz)) {
+    double dmin = (Xl - r_local.x()) / u.x();
+    double dmax = (Xl+(Nx*Px) - r_local.x()) / u.x();
+    if (dmin > dmax) std::swap(dmin, dmax);
+
+    double dymin = (Yl - r_local.y()) / u.y();
+    double dymax = (Yl+(Ny*Py) - r_local.y()) / u.y();
+    if (dymin > dymax) std::swap(dymin, dymax);
+
+    if ((dmin > dymax) || (dymin > dmax)) return INF;
+
+    if (dymin > dmin) dmin = dymin;
+
+    if (dymax < dmax) dmax = dymax; 
+
+    double dzmin = (Zl - r_local.z()) / u.z();
+    double dzmax = (Zl+(Nz*Pz) - r_local.z()) / u.z();
+    if (dzmin > dzmax) std::swap(dzmin, dzmax);
+
+    if ((dmin > dzmax) || (dzmin > dmax)) return INF;
+
+    if (dzmin > dmin) dmin = dzmin;
+
+    if (dzmax < dmax) dmax = dzmax;
+
+    if (dmin < 0. && dmax < 0.) return INF;
+
+    if (dmin < 0.) return dmax;
+
+    return dmin;
+  }
+
+  // If we are here, we are actually inside a lattice tile,
+  // so we just find the distance to the next tile.
+
   // Get the position of the center of the tile
   Position center = tile_center(tile[0], tile[1], tile[2]);
 
@@ -230,7 +270,7 @@ double RectLattice::distance_to_tile_boundary(
   double d_yh = diff_yh / u.y();
   double d_zl = diff_zl / u.z();
   double d_zh = diff_zh / u.z();
-
+  
   if (d_xl > 0. && d_xl < dist && std::abs(diff_xl) > 100 * SURFACE_COINCIDENT)
     dist = d_xl;
   if (d_xh > 0. && d_xh < dist && std::abs(diff_xh) > 100 * SURFACE_COINCIDENT)

--- a/src/slice_plot.cpp
+++ b/src/slice_plot.cpp
@@ -31,13 +31,15 @@
  * pris connaissance de la licence CeCILL, et que vous en avez accepté les
  * termes.
  *============================================================================*/
-#include <fstream>
 #include <geometry/cell.hpp>
 #include <geometry/geometry.hpp>
-#include <memory>
 #include <plotting/slice_plot.hpp>
 #include <simulation/tracker.hpp>
 #include <utils/error.hpp>
+#include <utils/rng.hpp>
+#include <utils/settings.hpp>
+#include <fstream>
+#include <memory>
 
 namespace plotter {
 
@@ -54,7 +56,6 @@ SlicePlot::SlicePlot(std::string fname, uint64_t pwidth, uint64_t pheight,
       image_matrix(),
       width_{width},
       height_{height},
-      rng(2617257382),
       create_color_mutex{} {}
 
 Pixel SlicePlot::get_color(::Cell* cell) {
@@ -313,9 +314,9 @@ Position SlicePlot::get_pixel_position(uint64_t i, uint64_t j) const {
 }
 
 Pixel SlicePlot::get_random_color() {
-  uint8_t r = static_cast<uint8_t>(255.0 * RNG::rand(rng));
-  uint8_t g = static_cast<uint8_t>(255.0 * RNG::rand(rng));
-  uint8_t b = static_cast<uint8_t>(255.0 * RNG::rand(rng));
+  uint8_t r = static_cast<uint8_t>(255.0 * RNG::rand(settings::rng));
+  uint8_t g = static_cast<uint8_t>(255.0 * RNG::rand(settings::rng));
+  uint8_t b = static_cast<uint8_t>(255.0 * RNG::rand(settings::rng));
 
   return {r, g, b};
 }

--- a/src/slice_plot.cpp
+++ b/src/slice_plot.cpp
@@ -31,15 +31,15 @@
  * pris connaissance de la licence CeCILL, et que vous en avez accepté les
  * termes.
  *============================================================================*/
+#include <fstream>
 #include <geometry/cell.hpp>
 #include <geometry/geometry.hpp>
+#include <memory>
 #include <plotting/slice_plot.hpp>
 #include <simulation/tracker.hpp>
 #include <utils/error.hpp>
 #include <utils/rng.hpp>
 #include <utils/settings.hpp>
-#include <fstream>
-#include <memory>
 
 namespace plotter {
 


### PR DESCRIPTION
This PR adds a large new feature: an interactive GUI geometry plotter. This is made possible with [Dear ImGui](https://github.com/ocornut/imgui), packaged in my [ImApp](https://github.com/HunterBelanger/ImApp) library for ease of use. You can now make slice plots, and move around/zoom and have the geometry rendered in real time. You are able to change the colors of different materials/cells, and also save the image as a PNG or JPG (no more .PPM files !).

Here is an example, using the BEAVRS geometry:
![gui_plotter](https://user-images.githubusercontent.com/29313793/204689888-03754e76-ba58-4f46-9c14-c235f44c4b04.png)

This also allowed me to make an improvement to the `RectLattice` class, only calculating the distance to the next tile if we are inside the lattice. Otherwise, the distance to lattice entry is calculated. I am not sure such an improvement is readily made for `HexLattice` however, as hexagonal lattices don't have "flat" sides.
