### PR TITLE
Statically Link HDF5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,13 +109,15 @@ FetchContent_MakeAvailable(Boost)
 
 #===============================================================================
 # Get HighFive
-message(STATUS "Downloading HighFive 2.7.1")
+message(STATUS "Downloading HighFive")
 set(HIGHFIVE_USE_BOOST OFF)
 set(HIGHFIVE_EXAMPLES OFF)
 set(HIGHFIVE_BUILD_DOCS OFF)
+set(HIGHFIVE_STATIC_HDF5 ON)
+set(HighFive_FIND_QUIETLY ON)
 FetchContent_Declare(HighFive
-  GIT_REPOSITORY https://github.com/BlueBrain/HighFive.git
-  GIT_TAG        v2.7.1
+  GIT_REPOSITORY https://github.com/HunterBelanger/HighFive.git
+  GIT_TAG        feature/hdf5_options
 )
 FetchContent_MakeAvailable(HighFive)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,8 +116,8 @@ set(HIGHFIVE_BUILD_DOCS OFF)
 set(HIGHFIVE_STATIC_HDF5 ON)
 set(HighFive_FIND_QUIETLY ON)
 FetchContent_Declare(HighFive
-  GIT_REPOSITORY https://github.com/HunterBelanger/HighFive.git
-  GIT_TAG        feature/hdf5_options
+  GIT_REPOSITORY https://github.com/BlueBrain/HighFive.git
+  GIT_TAG        master
 )
 FetchContent_MakeAvailable(HighFive)
 


### PR DESCRIPTION
I recently made a PR to the HighFive repo that allows for static linking with the HDF5 library.

This PR changes the branch for HighFive to master, where my change to HighFive was merged. Once a new stable release is out, I will change the HighFive version again. This should also suppress the warning about HighFive tests.