### PR TITLE
Noise Simulations for Operators

### DIFF
--- a/include/cancelator/approximate_mesh_cancelator.hpp
+++ b/include/cancelator/approximate_mesh_cancelator.hpp
@@ -44,6 +44,8 @@ class ApproximateMeshCancelator : public Cancelator {
   void check_particle_mover_compatibility(
       const std::shared_ptr<IParticleMover>& /*pmover*/) const override final {}
 
+  void write_output_info(H5::Group& grp) const override final;
+
  private:
   std::unordered_map<uint32_t, std::vector<BankedParticle*>> bins;
   std::vector<double> energy_edges;

--- a/include/cancelator/cancelator.hpp
+++ b/include/cancelator/cancelator.hpp
@@ -27,6 +27,7 @@
 
 #include <simulation/particle.hpp>
 #include <simulation/particle_mover.hpp>
+#include <utils/output.hpp>
 #include <utils/rng.hpp>
 
 #include <yaml-cpp/yaml.h>
@@ -46,6 +47,8 @@ class Cancelator {
 
   bool cancel_dual_weights() const { return dual_weights_; }
   void set_cancel_dual_weights(bool dw) { dual_weights_ = dw; }
+
+  virtual void write_output_info(H5::Group& grp) const = 0;
 
  protected:
   bool dual_weights_{false};

--- a/include/cancelator/exact_mg_cancelator.hpp
+++ b/include/cancelator/exact_mg_cancelator.hpp
@@ -50,6 +50,8 @@ class ExactMGCancelator : public Cancelator {
   void check_particle_mover_compatibility(
       const std::shared_ptr<IParticleMover>& pmover) const override final;
 
+  void write_output_info(H5::Group& grp) const override final;
+
   // Key which represents a unique cancellation bin for a
   // given position and energy group.
   // Key is public for MPI use

--- a/include/simulation/collision_operators/noise_branching_collision.hpp
+++ b/include/simulation/collision_operators/noise_branching_collision.hpp
@@ -39,9 +39,11 @@
 
 class NoiseBranchingCollision {
  public:
-  NoiseBranchingCollision(bool noise_gens): fission_operator(noise_gens) {}
+  NoiseBranchingCollision(bool noise_gens) : fission_operator(noise_gens) {}
 
-  bool noise_generations() const { return fission_operator.noise_generations(); }
+  bool noise_generations() const {
+    return fission_operator.noise_generations();
+  }
 
   void write_output_info(const std::string& base) const {
     if (mpi::rank != 0) return;

--- a/include/simulation/collision_operators/noise_branching_collision.hpp
+++ b/include/simulation/collision_operators/noise_branching_collision.hpp
@@ -39,7 +39,9 @@
 
 class NoiseBranchingCollision {
  public:
-  NoiseBranchingCollision() = default;
+  NoiseBranchingCollision(bool noise_gens): fission_operator(noise_gens) {}
+
+  bool noise_generations() const { return fission_operator.noise_generations(); }
 
   void write_output_info(const std::string& base) const {
     if (mpi::rank != 0) return;

--- a/include/simulation/collision_operators/noise_fission_operator.hpp
+++ b/include/simulation/collision_operators/noise_fission_operator.hpp
@@ -37,7 +37,9 @@
 
 class NoiseFissionOperator {
  public:
-  NoiseFissionOperator() = default;
+  NoiseFissionOperator(bool noise_gens): noise_generations_(noise_gens) {}
+
+  bool noise_generations() const { return noise_generations_; }
 
   void fission(Particle& p, const MicroXSs& xs, const Nuclide& nuc,
                double omega, double keff) const {
@@ -88,6 +90,8 @@ class NoiseFissionOperator {
   }
 
  private:
+  bool noise_generations_;
+
   int n_fission_neutrons(Particle& p, const MicroXSs& xs, double keff) const {
     // When transporting noise particles, we don't normalize the number of
     // generated particles by the weight ! We also scale by keff to make the
@@ -96,7 +100,11 @@ class NoiseFissionOperator {
   }
 
   void save_fission_particle(Particle& p, BankedParticle& fp) const {
-    p.make_secondary(fp.u, fp.E, fp.wgt, fp.wgt2);
+    if (noise_generations_) {
+      p.add_fission_particle(fp);
+    } else {
+      p.make_secondary(fp.u, fp.E, fp.wgt, fp.wgt2);
+    }
   }
 };
 

--- a/include/simulation/collision_operators/noise_fission_operator.hpp
+++ b/include/simulation/collision_operators/noise_fission_operator.hpp
@@ -37,7 +37,7 @@
 
 class NoiseFissionOperator {
  public:
-  NoiseFissionOperator(bool noise_gens): noise_generations_(noise_gens) {}
+  NoiseFissionOperator(bool noise_gens) : noise_generations_(noise_gens) {}
 
   bool noise_generations() const { return noise_generations_; }
 
@@ -96,7 +96,8 @@ class NoiseFissionOperator {
     // When transporting noise particles, we don't normalize the number of
     // generated particles by the weight ! We also scale by keff to make the
     // problem "critical".
-    return static_cast<int>(std::floor(xs.nu_total * xs.fission / (xs.total * keff) + p.rng()));
+    return static_cast<int>(
+        std::floor(xs.nu_total * xs.fission / (xs.total * keff) + p.rng()));
   }
 
   void save_fission_particle(Particle& p, BankedParticle& fp) const {

--- a/include/simulation/noise.hpp
+++ b/include/simulation/noise.hpp
@@ -37,13 +37,13 @@
 
 class Noise : public Simulation {
  public:
-  Noise(std::shared_ptr<IParticleMover> i_pm,
+  Noise(std::shared_ptr<INoiseParticleMover> i_pm,
         std::shared_ptr<IParticleMover> i_pipm, NoiseParameters noise_parms,
         NoiseMaker noise_mkr)
-      : Simulation(i_pm),
+      : Simulation(i_pipm),
         noise_params(noise_parms),
         noise_maker(noise_mkr),
-        pi_particle_mover(i_pipm) {}
+        noise_particle_mover(i_pm) {}
 
   void initialize() override final;
   void run() override final;
@@ -75,7 +75,7 @@ class Noise : public Simulation {
   Timer power_iteration_timer{};
   Timer convergence_timer{};
   Timer noise_batch_timer{};
-  std::shared_ptr<IParticleMover> pi_particle_mover = nullptr;
+  std::shared_ptr<INoiseParticleMover> noise_particle_mover = nullptr;
   std::shared_ptr<Cancelator> cancelator = nullptr;
   std::shared_ptr<Entropy> t_pre_entropy = nullptr;
   std::shared_ptr<Entropy> p_pre_entropy = nullptr;
@@ -119,5 +119,7 @@ class Noise : public Simulation {
   void sample_source_from_sources();
   void load_source_from_file();
 };
+
+std::shared_ptr<Noise> make_noise_simulator(const YAML::Node& sim);
 
 #endif

--- a/include/simulation/particle_mover.hpp
+++ b/include/simulation/particle_mover.hpp
@@ -28,6 +28,7 @@
 #include <materials/material_helper.hpp>
 #include <noise_source/noise_maker.hpp>
 #include <simulation/collision_operators/collision_operator.hpp>
+#include <simulation/collision_operators/noise_branching_collision.hpp>
 #include <simulation/particle.hpp>
 #include <simulation/tracker.hpp>
 #include <simulation/transport_operators/transport_operator.hpp>
@@ -63,15 +64,15 @@ class ParticleMover : public IParticleMover {
   ParticleMover(TransportOp t, CollisionOp c)
       : transport_operator_(t), collision_operator_(c) {}
 
-  bool exact_cancellation_compatible() const override final {
+  bool exact_cancellation_compatible() const override {
     return transport_operator_.exact_cancellation_compatible();
   }
 
-  bool track_length_compatible() const override final {
+  bool track_length_compatible() const override {
     return transport_operator_.track_length_compatible();
   }
 
-  void write_output_info(const std::string& base = "") const override final {
+  void write_output_info(const std::string& base = "") const override {
     transport_operator_.write_output_info(base);
     collision_operator_.write_output_info(base);
   }
@@ -80,7 +81,7 @@ class ParticleMover : public IParticleMover {
       std::vector<Particle>& bank,
       std::optional<NoiseParameters> noise = std::nullopt,
       std::vector<BankedParticle>* noise_bank = nullptr,
-      const NoiseMaker* noise_maker = nullptr) override final {
+      const NoiseMaker* noise_maker = nullptr) override {
 #ifdef ABEILLE_USE_OMP
 #pragma omp parallel
 #endif
@@ -188,7 +189,7 @@ class ParticleMover : public IParticleMover {
     return fission_neutrons;
   }
 
- private:
+ protected:
   TransportOp transport_operator_;
   CollisionOp collision_operator_;
 
@@ -226,6 +227,42 @@ class ParticleMover : public IParticleMover {
     }
   }
 };
+
+class INoiseParticleMover : public IParticleMover {
+  public:
+    INoiseParticleMover() = default;
+    virtual ~INoiseParticleMover() = default;
+
+    virtual bool noise_generations() const = 0;
+};
+
+template <TransportOperator TransportOp>
+class NoiseParticleMover : public ParticleMover<TransportOp, NoiseBranchingCollision>, public INoiseParticleMover {
+  public:
+    NoiseParticleMover(TransportOp t, NoiseBranchingCollision c): ParticleMover<TransportOp, NoiseBranchingCollision>(t, c) {}
+
+    std::vector<BankedParticle> transport(std::vector<Particle>& bank, std::optional<NoiseParameters> noise = std::nullopt, std::vector<BankedParticle>* noise_bank = nullptr, const NoiseMaker* noise_maker = nullptr) override final {
+      return ParticleMover<TransportOp, NoiseBranchingCollision>::transport(bank, noise, noise_bank, noise_maker);
+    }
+    
+    bool exact_cancellation_compatible() const override final {
+      return ParticleMover<TransportOp, NoiseBranchingCollision>::exact_cancellation_compatible();
+    }
+
+    bool track_length_compatible() const override final {
+      return ParticleMover<TransportOp, NoiseBranchingCollision>::track_length_compatible();
+    }
+    
+    void write_output_info(const std::string& base = "") const override final {
+      ParticleMover<TransportOp, NoiseBranchingCollision>::write_output_info(base);
+    }
+
+    bool noise_generations() const override final {
+      return this->collision_operator_.noise_generations();
+    };
+};
+
+std::shared_ptr<INoiseParticleMover> make_noise_particle_mover(const YAML::Node& sim);
 
 std::shared_ptr<IParticleMover> make_particle_mover(const YAML::Node& sim,
                                                     settings::SimMode mode);

--- a/include/simulation/particle_mover.hpp
+++ b/include/simulation/particle_mover.hpp
@@ -229,40 +229,52 @@ class ParticleMover : public IParticleMover {
 };
 
 class INoiseParticleMover : public IParticleMover {
-  public:
-    INoiseParticleMover() = default;
-    virtual ~INoiseParticleMover() = default;
+ public:
+  INoiseParticleMover() = default;
+  virtual ~INoiseParticleMover() = default;
 
-    virtual bool noise_generations() const = 0;
+  virtual bool noise_generations() const = 0;
 };
 
 template <TransportOperator TransportOp>
-class NoiseParticleMover : public ParticleMover<TransportOp, NoiseBranchingCollision>, public INoiseParticleMover {
-  public:
-    NoiseParticleMover(TransportOp t, NoiseBranchingCollision c): ParticleMover<TransportOp, NoiseBranchingCollision>(t, c) {}
+class NoiseParticleMover
+    : public ParticleMover<TransportOp, NoiseBranchingCollision>,
+      public INoiseParticleMover {
+ public:
+  NoiseParticleMover(TransportOp t, NoiseBranchingCollision c)
+      : ParticleMover<TransportOp, NoiseBranchingCollision>(t, c) {}
 
-    std::vector<BankedParticle> transport(std::vector<Particle>& bank, std::optional<NoiseParameters> noise = std::nullopt, std::vector<BankedParticle>* noise_bank = nullptr, const NoiseMaker* noise_maker = nullptr) override final {
-      return ParticleMover<TransportOp, NoiseBranchingCollision>::transport(bank, noise, noise_bank, noise_maker);
-    }
-    
-    bool exact_cancellation_compatible() const override final {
-      return ParticleMover<TransportOp, NoiseBranchingCollision>::exact_cancellation_compatible();
-    }
+  std::vector<BankedParticle> transport(
+      std::vector<Particle>& bank,
+      std::optional<NoiseParameters> noise = std::nullopt,
+      std::vector<BankedParticle>* noise_bank = nullptr,
+      const NoiseMaker* noise_maker = nullptr) override final {
+    return ParticleMover<TransportOp, NoiseBranchingCollision>::transport(
+        bank, noise, noise_bank, noise_maker);
+  }
 
-    bool track_length_compatible() const override final {
-      return ParticleMover<TransportOp, NoiseBranchingCollision>::track_length_compatible();
-    }
-    
-    void write_output_info(const std::string& base = "") const override final {
-      ParticleMover<TransportOp, NoiseBranchingCollision>::write_output_info(base);
-    }
+  bool exact_cancellation_compatible() const override final {
+    return ParticleMover<
+        TransportOp, NoiseBranchingCollision>::exact_cancellation_compatible();
+  }
 
-    bool noise_generations() const override final {
-      return this->collision_operator_.noise_generations();
-    };
+  bool track_length_compatible() const override final {
+    return ParticleMover<TransportOp,
+                         NoiseBranchingCollision>::track_length_compatible();
+  }
+
+  void write_output_info(const std::string& base = "") const override final {
+    ParticleMover<TransportOp, NoiseBranchingCollision>::write_output_info(
+        base);
+  }
+
+  bool noise_generations() const override final {
+    return this->collision_operator_.noise_generations();
+  };
 };
 
-std::shared_ptr<INoiseParticleMover> make_noise_particle_mover(const YAML::Node& sim);
+std::shared_ptr<INoiseParticleMover> make_noise_particle_mover(
+    const YAML::Node& sim);
 
 std::shared_ptr<IParticleMover> make_particle_mover(const YAML::Node& sim,
                                                     settings::SimMode mode);

--- a/include/utils/russian_roulette.hpp
+++ b/include/utils/russian_roulette.hpp
@@ -31,7 +31,7 @@
 
 #include <cmath>
 
-void russian_roulette(Particle& p) {
+inline void russian_roulette(Particle& p) {
   // Roulette first weight
   if (std::abs(p.wgt()) < settings::wgt_cutoff) {
     double P_kill = 1.0 - (std::abs(p.wgt()) / settings::wgt_survival);

--- a/input_files/noise_oscillation.yaml
+++ b/input_files/noise_oscillation.yaml
@@ -127,7 +127,7 @@ settings:
 
 simulation:
   mode: noise
-  nparticles: 10000
+  nparticles: 100000
   nbatches: 2000
   nignored: 10
   nskip: 3
@@ -144,15 +144,9 @@ simulation:
     hi: [10.71, 10.71, 2.00]
 
   sources:
-    - spatial:
-        type: box
-        low: [-10.71, -10.71, -2.00]
-        hi: [10.71, 10.71, 2.00]
-      direction:
-        type: isotropic
-      energy:
-        type: mono-energetic
-        energy: 0.5
+    - spatial: {type: box, low: [-10.71, -10.71, -2.00], hi: [10.71, 10.71, 2.00]}
+      direction: {type: isotropic}
+      energy: {type: mono-energetic, energy: 0.5}
       weight: 1.
 
   noise-sources:

--- a/input_files/noise_oscillation.yaml
+++ b/input_files/noise_oscillation.yaml
@@ -86,38 +86,6 @@ universes:
 
 root-universe: 4
 
-sources:
-  - spatial:
-      type: box
-      low: [-10.71, -10.71, -2.00]
-      hi: [10.71, 10.71, 2.00]
-    direction:
-      type: isotropic
-    energy:
-      type: mono-energetic
-      energy: 0.5
-    weight: 1.
-
-cancelator:
-  type: approximate
-  shape: [170, 170, 170]
-  low: [-10.71, -10.71, -2.00]
-  hi: [10.71, 10.71, 2.00]
-
-noise-sources:
-  - type: square-oscillation
-    low: [2.1543, -2.8857, -2.00]
-    hi: [2.8857, -2.1543, 2.00]
-    angular-frequency: 6.28318531 # 2 pi
-    epsilon-total: 0.041
-    epsilon-fission: 0.021
-    epsilon-scatter: 0.034
-
-entropy:
-  low: [-10.71, -10.71, -2.00]
-  hi: [10.71, 10.71, 2.00]
-  shape: [17, 17, 1]
-
 tallies:
   - low: [1.5, -3.5, -2.]
     hi: [3.5, -1.5, 2.]
@@ -152,28 +120,51 @@ tallies:
     name: imag-flux
 
 settings:
-  nparticles: 100000
-  ngenerations: 2000
+  ngroups: 2
+  energy-mode: multi-group
+  energy-bounds: [0., 1., 2.]
+  #max-run-time: 5. # Minutes
+
+simulation:
+  mode: noise
+  nparticles: 10000
+  nbatches: 2000
   nignored: 10
   nskip: 3
-  ngroups: 2
-  transport: surface-tracking
-  #simulation: k-eigenvalue
-  simulation: noise 
   noise-cancellation: true
   inner-generations: true
   normalize-noise-source: true
-  #max-run-time: 5. # Minutes
   noise-angular-frequency: 6.28318531
   keff: 0.99916
-  energy-mode: multi-group
-  energy-bounds: [0., 1., 2.]
-  
-plots:
-  - type: slice
-    basis: xy
-    resolution: [1000, 1000]
-    origin: [0., 0., 0.]
-    dimensions: [21.58, 21.58] 
-    color: material
-    name: noise_assembly_plot
+
+  cancelator:
+    type: approximate
+    shape: [170, 170, 170]
+    low: [-10.71, -10.71, -2.00]
+    hi: [10.71, 10.71, 2.00]
+
+  sources:
+    - spatial:
+        type: box
+        low: [-10.71, -10.71, -2.00]
+        hi: [10.71, 10.71, 2.00]
+      direction:
+        type: isotropic
+      energy:
+        type: mono-energetic
+        energy: 0.5
+      weight: 1.
+
+  noise-sources:
+    - type: square-oscillation
+      low: [2.1543, -2.8857, -2.00]
+      hi: [2.8857, -2.1543, 2.00]
+      angular-frequency: 6.28318531 # 2 pi
+      epsilon-total: 0.041
+      epsilon-fission: 0.021
+      epsilon-scatter: 0.034
+
+  entropy:
+    low: [-10.71, -10.71, -2.00]
+    hi: [10.71, 10.71, 2.00]
+    shape: [17, 17, 1]

--- a/input_files/noise_vibration.yaml
+++ b/input_files/noise_vibration.yaml
@@ -7,7 +7,6 @@ materials:
                 [0., 0.39276]]
     absorption: [0.025755, 0.15788]
     fission:    [0.0057671, 0.10622]
-    #nu:  [2.59068, 2.59068]
     nu_prompt:  [2.576819862, 2.576819862]
     nu_delayed: [0.013860138, 0.013860138]
     chi:        [[1., 0.]]
@@ -15,7 +14,6 @@ materials:
       probabilities: [1.]
       constants: [0.0851]
     group-speeds: [1.82304E7, 4.13067E5] # [cm / s]
-
     
   - id: 2
     name: Water
@@ -87,47 +85,6 @@ universes:
 
 root-universe: 4
 
-sources:
-  - spatial:
-      type: box
-      low: [-10.71, -10.71, -2.00]
-      hi: [10.71, 10.71, 2.00]
-    direction:
-      type: isotropic
-    energy:
-      type: mono-energetic
-      energy: 0.5
-    weight: 1.
-
-cancelator:
-  type: approximate
-  shape: [170, 170, 1]
-  low: [-10.71, -10.71, -2.00]
-  hi: [10.71, 10.71, 2.00]
-  beta: average-g
-
-noise-sources:
-  - type: flat-vibration
-    low: [2.1543, -2.3543, -2.00]
-    hi: [2.8857, -1.9543, 2.00]
-    angular-frequency: 6.28318531 # 2 pi
-    direction: Y
-    positive-material: 2 # Water
-    negative-material: 1 # Fuel
-
-  - type: flat-vibration
-    low: [2.1543, -3.0857, -2.00]
-    hi: [2.8857, -2.6857, 2.00]
-    angular-frequency: 6.28318531 # 2 pi
-    direction: Y
-    positive-material: 1 # Fuel
-    negative-material: 2 # Water
-
-entropy:
-  low: [-10.71, -10.71, -2.00]
-  hi: [10.71, 10.71, 2.00]
-  shape: [17, 17, 1]
-
 tallies:
  #- low: [-10.79, -10.79, -2.00]
  #  hi: [10.79, 10.79, 2.00]
@@ -170,28 +127,60 @@ tallies:
     name: imag-flux
 
 settings:
+  ngroups: 2
+  energy-mode: multi-group
+  energy-bounds: [0., 1., 2.]
+  #max-run-time: 5. # Minutes
+
+simulation:
+  mode: noise
   nparticles: 100000
-  ngenerations: 2100
+  nbatches: 2000
   nignored: 10
   nskip: 3
-  ngroups: 2
-  seed: 238623543
-  transport: surface-tracking
-  #simulation: k-eigenvalue
-  simulation: noise 
-  noise-cancellation: true
+  noise-cancellation: false
   inner-generations: true
   normalize-noise-source: true
   noise-angular-frequency: 6.28318531
   keff: 0.99916
-  energy-mode: multi-group
-  energy-bounds: [0., 1., 2.]
-  
-plots:
-  - type: slice
-    basis: xy
-    resolution: [1000, 1000]
-    origin: [0., 0., 0.]
-    dimensions: [21.58, 21.58] 
-    color: material
-    name: noise_assembly_plot
+
+  sources:
+    - spatial:
+        type: box
+        low: [-10.71, -10.71, -2.00]
+        hi: [10.71, 10.71, 2.00]
+      direction:
+        type: isotropic
+      energy:
+        type: mono-energetic
+        energy: 0.5
+      weight: 1.
+
+  cancelator:
+    type: approximate
+    shape: [170, 170, 1]
+    low: [-10.71, -10.71, -2.00]
+    hi: [10.71, 10.71, 2.00]
+    beta: average-g
+
+  noise-sources:
+    - type: flat-vibration
+      low: [2.1543, -2.3543, -2.00]
+      hi: [2.8857, -1.9543, 2.00]
+      angular-frequency: 6.28318531 # 2 pi
+      direction: Y
+      positive-material: 2 # Water
+      negative-material: 1 # Fuel
+
+    - type: flat-vibration
+      low: [2.1543, -3.0857, -2.00]
+      hi: [2.8857, -2.6857, 2.00]
+      angular-frequency: 6.28318531 # 2 pi
+      direction: Y
+      positive-material: 1 # Fuel
+      negative-material: 2 # Water
+
+  entropy:
+    low: [-10.71, -10.71, -2.00]
+    hi: [10.71, 10.71, 2.00]
+    shape: [17, 17, 1]

--- a/src/approximate_mesh_cancelator.cpp
+++ b/src/approximate_mesh_cancelator.cpp
@@ -118,6 +118,20 @@ ApproximateMeshCancelator::ApproximateMeshCancelator(
   Sl = 1;
 }
 
+void ApproximateMeshCancelator::write_output_info(H5::Group& grp) const {
+  const std::array<std::size_t, 3> shp{shape[0], shape[1], shape[2]};
+  const std::array<double, 3> rlw{r_low.x(), r_low.y(), r_low.z()};
+  const std::array<double, 3> rhi{r_hi.x(), r_hi.y(), r_hi.z()};
+
+  grp.createAttribute("type", "approximate");
+  grp.createAttribute("shape", shp);
+  grp.createAttribute("low", rlw);
+  grp.createAttribute("hi", rhi);
+  if (energy_edges.empty() == false) {
+    grp.createAttribute("energy-bounds", energy_edges);
+  }
+}
+
 bool ApproximateMeshCancelator::add_particle(BankedParticle& p) {
   // Get bin indicies for spacial coordinates
   int i = static_cast<int>(std::floor((p.r.x() - r_low.x()) / dx));

--- a/src/exact_mg_cancelator.cpp
+++ b/src/exact_mg_cancelator.cpp
@@ -114,6 +114,23 @@ ExactMGCancelator::ExactMGCancelator(
   if (Key::shape[3] == 0) Key::shape[3] = 1;
 }
 
+void ExactMGCancelator::write_output_info(H5::Group& grp) const {
+  const std::array<std::size_t, 3> shp{Key::shape[0], Key::shape[1],
+                                       Key::shape[2]};
+  const std::array<double, 3> rlw{Key::r_low.x(), Key::r_low.y(),
+                                  Key::r_low.z()};
+  const std::array<double, 3> rhi{Key::r_hi.x(), Key::r_hi.y(), Key::r_hi.z()};
+
+  grp.createAttribute("type", "exact-mg");
+  grp.createAttribute("shape", shp);
+  grp.createAttribute("low", rlw);
+  grp.createAttribute("hi", rhi);
+  grp.createAttribute("nsamples", N_SAMPLES);
+  if (Key::group_bins.empty() == false) {
+    grp.createAttribute("group-bins", Key::group_bins);
+  }
+}
+
 void ExactMGCancelator::check_particle_mover_compatibility(
     const std::shared_ptr<IParticleMover>& pmover) const {
   if (pmover->exact_cancellation_compatible() == false) {

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -30,6 +30,7 @@
 #include <utils/timer.hpp>
 
 #include <iomanip>
+#include <limits>
 #include <numeric>
 #include <sstream>
 
@@ -53,7 +54,7 @@ void Noise::initialize() {
 
   Tallies::instance().allocate_batch_arrays(nbatches * nskip + nignored);
   Tallies::instance().verify_track_length_tallies(
-      particle_mover->track_length_compatible());
+      noise_particle_mover->track_length_compatible());
 }
 
 void Noise::write_output_info() const {
@@ -74,8 +75,8 @@ void Noise::write_output_info() const {
   if (in_source_file_name.empty() == false)
     h5.createAttribute("source-file", in_source_file_name);
 
-  particle_mover->write_output_info("noise-");
-  pi_particle_mover->write_output_info("power-iterator-");
+  noise_particle_mover->write_output_info("noise-");
+  particle_mover->write_output_info("power-iterator-");
 }
 
 void Noise::set_entropy(const Entropy& entropy) {
@@ -422,11 +423,9 @@ void Noise::power_iteration(bool sample_noise) {
 
   std::vector<BankedParticle> next_gen;
   if (sample_noise == false) {
-    next_gen =
-        pi_particle_mover->transport(bank, std::nullopt, nullptr, nullptr);
+    next_gen = particle_mover->transport(bank, std::nullopt, nullptr, nullptr);
   } else {
-    next_gen = pi_particle_mover->transport(bank, std::nullopt, &noise_bank,
-                                            &noise_maker);
+    next_gen = particle_mover->transport(bank, std::nullopt, &noise_bank, &noise_maker);
   }
 
   if (next_gen.size() == 0) {
@@ -586,7 +585,7 @@ void Noise::noise_simulation() {
            << " particles \n";
 
     auto fission_bank =
-        particle_mover->transport(nbank, noise_params, nullptr, nullptr);
+        noise_particle_mover->transport(nbank, noise_params, nullptr, nullptr);
     if (noise_gen == 1) transported_histories += bank.size();
 
     // Cancellation may be performed on fission_bank here if we have provided
@@ -853,4 +852,175 @@ void Noise::zero_entropy() {
   if (t_post_entropy) {
     t_post_entropy->zero();
   }
+}
+
+std::shared_ptr<Noise> make_noise_simulator(const YAML::Node& sim) {
+  // Get the number of particles
+  if (!sim["nparticles"] || sim["nparticles"].IsScalar() == false) {
+    fatal_error("No nparticles entry in noise simulation.");
+  }
+  std::size_t nparticles = sim["nparticles"].as<std::size_t>();
+
+  // Get the number of noise batches
+  if (!sim["nbatches"] || sim["nbatches"].IsScalar() == false) {
+    fatal_error("No nbatches entry in noise simulation.");
+  }
+  std::size_t ngenerations = sim["nbatches"].as<std::size_t>();
+
+  // Get the number of ignored generations
+  if (!sim["nignored"] || sim["nignored"].IsScalar() == false) {
+    fatal_error("No nignored entry in noise simulation.");
+  }
+  std::size_t nignored = sim["nignored"].as<std::size_t>();
+
+  // Get the number of skipped generations between noise sampling
+  if (!sim["nskip"] || sim["nskip"].IsScalar() == false) {
+    fatal_error("No nskip entry in noise simulation.");
+  }
+  std::size_t nskip = sim["nskip"].as<std::size_t>();
+
+  std::string in_source_file;
+  if (sim["source-file"] && sim["source-file"].IsScalar()) {
+    in_source_file = sim["source-file"].as<std::string>();
+  } else if (sim["source-file"]) {
+    fatal_error("Invalid source-file entry in k-eigenvalue simulation.");
+  }
+
+  // Read all sources if we don't have a source file
+  std::vector<std::shared_ptr<Source>> sources;
+  if (in_source_file.empty()) {
+    if (!sim["sources"] || sim["sources"].IsSequence() == false) {
+      fatal_error("No sources entry in noise simulation.");
+    }
+    for (std::size_t s = 0; s < sim["sources"].size(); s++) {
+      sources.push_back(make_source(sim["sources"][s]));
+    }
+  }
+
+  // For noise, we need a NoiseMaker. We will now read in all of the provided
+  // noise sources in the simulation entry
+  NoiseMaker noise_maker;
+  if (!sim["noise-sources"] || sim["noise-sources"].IsSequence() == false) {
+    fatal_error("No noise-sources entry in noise simulation.");
+  }
+  for (std::size_t s = 0; s < sim["noise-sources"].size(); s++) {
+    noise_maker.add_noise_source(sim["noise-sources"][s]);
+  }
+
+  bool normalize_noise_source = true;
+  if (sim["normalize-noise-source"] && sim["normalize-noise-source"].IsScalar()) {
+    normalize_noise_source = sim["normalize-noise-source"].as<bool>();
+  } else if (sim["normalize-noise-source"]) {
+    fatal_error("Invalid normalize-noise-source entry provided in noise simulation.");
+  }
+
+  // Get entropy bins
+  std::optional<Entropy> entropy = std::nullopt;
+  if (sim["entropy"] && sim["entropy"].IsMap()) {
+    entropy = make_entropy(sim["entropy"]);
+  } else if (sim["entropy"]) {
+    fatal_error("Invalid entropy entry in noise simulation.");
+  }
+
+  // For noise simulations, we need two different particle movers. One for the
+  // noise particles and one for the normal particles in power iteration. We
+  // start by making the particle mover for noise. It will use the prescribed
+  // transport operator, but will always use NoiseBranchingCollision.
+  std::shared_ptr<INoiseParticleMover> noise_mover = make_noise_particle_mover(sim);
+
+  // Now we can get the particle mover for power iteration. This will sue the
+  // same transport operator, but will use the prescribed collision operator
+  // in the input file.
+  std::shared_ptr<IParticleMover> pi_mover = make_particle_mover(sim, settings::SimMode::KEFF);
+
+  std::size_t ncancel_noise_gens = std::numeric_limits<std::size_t>::max();
+  if (sim["ncancel-noise-gens"] && sim["ncancel-noise-gens"].IsScalar()) {
+    ncancel_noise_gens = sim["ncancel-noise-gens"].as<std::size_t>();
+  } else if (sim["ncancel-noise-gens"]) {
+    fatal_error("Invalid ncancel-noise-gens entry provided in noise simulation.");
+  }
+
+  // Get cancelator
+  std::shared_ptr<Cancelator> cancelator = nullptr;
+  if (sim["cancelator"] && sim["cancelator"].IsMap()) {
+    cancelator = make_cancelator(sim["cancelator"]);
+  } else if (sim["cancelator"]) {
+    fatal_error("Invalid cancelator entry in noise simulation.");
+  }
+
+  // Check for regional cancellation options. By default, we assume noise
+  // cancellation if a cancelator is present.
+  bool noise_cancellation = cancelator ? true : false;
+  if (sim["noise-cancellation"] && sim["noise-cancellation"].IsScalar()) {
+    noise_cancellation = sim["noise-cancellation"].as<bool>();
+  } else if (sim["noise-cancellation"]) {
+    fatal_error("Invalid noise-cancellation entry in noise simulation.");
+  }
+
+  bool cancellation = false;
+  if (sim["cancellation"] && sim["cancellation"].IsScalar()) {
+    noise_cancellation = sim["cancellation"].as<bool>();
+  } else if (sim["cancellation"]) {
+    fatal_error("Invalid cancellation entry in noise simulation.");
+  }
+
+  if ((noise_cancellation || cancellation) && cancelator == nullptr) {
+    fatal_error("Cancellation is desired, but no cancelator was provided in noise simulation.");
+  } 
+
+  // Make sure our transport operators are compatible with cancellation !
+  if (noise_cancellation) {
+    cancelator->check_particle_mover_compatibility(noise_mover);
+  }
+  if (cancellation) {
+    cancelator->check_particle_mover_compatibility(pi_mover);
+  }
+
+  // Read in noise parameters
+  double omega;
+  if (!sim["noise-angular-frequency"] || sim["noise-angular-frequency"].IsScalar() == false) {
+    fatal_error("No valid noise-angular-frequency entry provided in noise simulation.");
+  }
+  omega = sim["noise-angular-frequency"].as<double>();
+
+  double keff;
+  if (!sim["keff"] || sim["keff"].IsScalar() == false) {
+    fatal_error("No valid keff entry provided in noise simulation.");
+  }
+  keff = sim["keff"].as<double>();
+
+  double eta = 1.;
+  if (sim["eta"] && sim["eta"].IsScalar()) {
+    eta = sim["eta"].as<double>();
+  } else if (sim["eta"]) {
+    fatal_error("Invalid eta entry provided in noise simulation.");
+  }
+
+  NoiseParameters noise_params;
+  noise_params.omega = omega;
+  noise_params.keff = keff;
+  noise_params.eta = eta;
+
+  // Create simulation
+  std::shared_ptr<Noise> simptr = std::make_shared<Noise>(noise_mover, pi_mover, noise_params, noise_maker);
+
+  // Set quantities
+  simptr->set_nparticles(nparticles);
+  simptr->set_nbatches(ngenerations);
+  simptr->set_nignored(nignored);
+  simptr->set_nskip(nskip);
+  simptr->set_normalize_noise_source(normalize_noise_source);
+  simptr->set_ncancel_noise_gens(ncancel_noise_gens); 
+  if (cancelator) simptr->set_cancelator(cancelator);
+  simptr->set_regional_cancellation(cancellation);
+  simptr->set_regional_cancellation_noise(noise_cancellation);
+  for (const auto& src : sources) {
+    simptr->add_source(src);
+  }
+  if (in_source_file.empty() == false) {
+    simptr->set_in_source_file(in_source_file);
+  }
+  if (entropy) simptr->set_entropy(*entropy);
+
+  return simptr;
 }

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -1001,6 +1001,8 @@ std::shared_ptr<Noise> make_noise_simulator(const YAML::Node& sim) {
   noise_params.keff = keff;
   noise_params.eta = eta;
 
+  noise_maker.noise_parameters() = noise_params;
+
   // Create simulation
   std::shared_ptr<Noise> simptr = std::make_shared<Noise>(noise_mover, pi_mover, noise_params, noise_maker);
 

--- a/src/noise_maker.cpp
+++ b/src/noise_maker.cpp
@@ -348,7 +348,7 @@ void NoiseMaker::sample_oscillation_noise_scatter(Particle& p,
 
   std::complex<double> wgt{p.wgt(), p.wgt2()};
   wgt *= sinfo.yield * sinfo.weight_modifier;  // Multiply by scattering yield
-  wgt *= P_scatter;    // Implicit capture
+  wgt *= P_scatter;                            // Implicit capture
 
   // Get the complex weight factor
   std::complex<double> dE_E{0., 0.};

--- a/src/noise_maker.cpp
+++ b/src/noise_maker.cpp
@@ -347,7 +347,7 @@ void NoiseMaker::sample_oscillation_noise_scatter(Particle& p,
                          p.Esmp()};
 
   std::complex<double> wgt{p.wgt(), p.wgt2()};
-  wgt *= sinfo.yield;  // Multiply by scattering yield
+  wgt *= sinfo.yield * sinfo.weight_modifier;  // Multiply by scattering yield
   wgt *= P_scatter;    // Implicit capture
 
   // Get the complex weight factor

--- a/src/particle_mover.cpp
+++ b/src/particle_mover.cpp
@@ -132,17 +132,22 @@ std::shared_ptr<IParticleMover> make_concrete_mover(const YAML::Node& sim,
   return nullptr;
 }
 
-std::shared_ptr<INoiseParticleMover> make_concrete_noise_mover(const YAML::Node& sim, const NoiseBranchingCollision& cop) {
+std::shared_ptr<INoiseParticleMover> make_concrete_noise_mover(
+    const YAML::Node& sim, const NoiseBranchingCollision& cop) {
   TransporterObjct top = make_transporter(sim);
 
   if (std::holds_alternative<SurfaceTracker>(top)) {
-    return std::make_shared<NoiseParticleMover<SurfaceTracker>>(std::get<SurfaceTracker>(top), cop);
+    return std::make_shared<NoiseParticleMover<SurfaceTracker>>(
+        std::get<SurfaceTracker>(top), cop);
   } else if (std::holds_alternative<DeltaTracker>(top)) {
-    return std::make_shared<NoiseParticleMover<DeltaTracker>>(std::get<DeltaTracker>(top), cop);
+    return std::make_shared<NoiseParticleMover<DeltaTracker>>(
+        std::get<DeltaTracker>(top), cop);
   } else if (std::holds_alternative<ImplicitLeakageDeltaTracker>(top)) {
-    return std::make_shared<NoiseParticleMover<ImplicitLeakageDeltaTracker>>(std::get<ImplicitLeakageDeltaTracker>(top), cop);
+    return std::make_shared<NoiseParticleMover<ImplicitLeakageDeltaTracker>>(
+        std::get<ImplicitLeakageDeltaTracker>(top), cop);
   } else if (std::holds_alternative<CarterTracker>(top)) {
-    return std::make_shared<NoiseParticleMover<CarterTracker>>(std::get<CarterTracker>(top), cop);
+    return std::make_shared<NoiseParticleMover<CarterTracker>>(
+        std::get<CarterTracker>(top), cop);
   }
 
   // Should never get here !
@@ -150,23 +155,25 @@ std::shared_ptr<INoiseParticleMover> make_concrete_noise_mover(const YAML::Node&
   return nullptr;
 }
 
-std::shared_ptr<INoiseParticleMover> make_noise_particle_mover(const YAML::Node& sim) {
+std::shared_ptr<INoiseParticleMover> make_noise_particle_mover(
+    const YAML::Node& sim) {
   bool noise_generations = true;
   if (sim["noise-generations"] && sim["noise-generations"].IsScalar()) {
     noise_generations = sim["noise-generations"].as<bool>();
   } else if (sim["noise-generations"]) {
     fatal_error("Invalid noise-generations entry in noise simulation.");
   }
-  
+
   // If this is for a noise simulation, we only have one type of collison
   // operator at the moment, so nothing to check other than the mode.
-  return make_concrete_noise_mover(sim, NoiseBranchingCollision(noise_generations));
+  return make_concrete_noise_mover(sim,
+                                   NoiseBranchingCollision(noise_generations));
 }
 
 std::shared_ptr<IParticleMover> make_particle_mover(const YAML::Node& sim,
                                                     settings::SimMode mode) {
   if (mode == settings::SimMode::NOISE) {
-    fatal_error("Cannot create a particle mover for noise here."); 
+    fatal_error("Cannot create a particle mover for noise here.");
   }
 
   // Next, we get the collision operator type

--- a/src/particle_mover.cpp
+++ b/src/particle_mover.cpp
@@ -132,12 +132,41 @@ std::shared_ptr<IParticleMover> make_concrete_mover(const YAML::Node& sim,
   return nullptr;
 }
 
+std::shared_ptr<INoiseParticleMover> make_concrete_noise_mover(const YAML::Node& sim, const NoiseBranchingCollision& cop) {
+  TransporterObjct top = make_transporter(sim);
+
+  if (std::holds_alternative<SurfaceTracker>(top)) {
+    return std::make_shared<NoiseParticleMover<SurfaceTracker>>(std::get<SurfaceTracker>(top), cop);
+  } else if (std::holds_alternative<DeltaTracker>(top)) {
+    return std::make_shared<NoiseParticleMover<DeltaTracker>>(std::get<DeltaTracker>(top), cop);
+  } else if (std::holds_alternative<ImplicitLeakageDeltaTracker>(top)) {
+    return std::make_shared<NoiseParticleMover<ImplicitLeakageDeltaTracker>>(std::get<ImplicitLeakageDeltaTracker>(top), cop);
+  } else if (std::holds_alternative<CarterTracker>(top)) {
+    return std::make_shared<NoiseParticleMover<CarterTracker>>(std::get<CarterTracker>(top), cop);
+  }
+
+  // Should never get here !
+  fatal_error("Something has gone very wrong");
+  return nullptr;
+}
+
+std::shared_ptr<INoiseParticleMover> make_noise_particle_mover(const YAML::Node& sim) {
+  bool noise_generations = true;
+  if (sim["noise-generations"] && sim["noise-generations"].IsScalar()) {
+    noise_generations = sim["noise-generations"].as<bool>();
+  } else if (sim["noise-generations"]) {
+    fatal_error("Invalid noise-generations entry in noise simulation.");
+  }
+  
+  // If this is for a noise simulation, we only have one type of collison
+  // operator at the moment, so nothing to check other than the mode.
+  return make_concrete_noise_mover(sim, NoiseBranchingCollision(noise_generations));
+}
+
 std::shared_ptr<IParticleMover> make_particle_mover(const YAML::Node& sim,
                                                     settings::SimMode mode) {
-  // If thsi is for a noise simulation, we only have one type of collison
-  // operator at the moment, so nothing to check other than the mode.
   if (mode == settings::SimMode::NOISE) {
-    return make_concrete_mover(sim, NoiseBranchingCollision());
+    fatal_error("Cannot create a particle mover for noise here."); 
   }
 
   // Next, we get the collision operator type

--- a/src/power_iterator.cpp
+++ b/src/power_iterator.cpp
@@ -88,6 +88,8 @@ void PowerIterator::write_output_info() const {
 
   if (cancelator) {
     h5.createAttribute("regional-cancellation", true);
+    auto cancelator_grp = h5.createGroup("cancelator");
+    cancelator->write_output_info(cancelator_grp);
   } else {
     h5.createAttribute("regional-cancellation", false);
   }

--- a/src/power_iterator.cpp
+++ b/src/power_iterator.cpp
@@ -979,7 +979,7 @@ void PowerIterator::perform_regional_cancellation(
 std::shared_ptr<PowerIterator> make_power_iterator(const YAML::Node& sim) {
   // Get the number of particles
   if (!sim["nparticles"] || sim["nparticles"].IsScalar() == false) {
-    fatal_error("No nparticles entry in fixed-source simulation.");
+    fatal_error("No nparticles entry in k-eigenvalue simulation.");
   }
   std::size_t nparticles = sim["nparticles"].as<std::size_t>();
 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -24,6 +24,7 @@
  * */
 #include <simulation/fixed_source.hpp>
 #include <simulation/power_iterator.hpp>
+#include <simulation/noise.hpp>
 #include <simulation/simulation.hpp>
 #include <utils/error.hpp>
 #include <utils/mpi.hpp>
@@ -231,7 +232,7 @@ std::shared_ptr<Simulation> make_simulation(const YAML::Node& input) {
   } else if (mode == "modified-fixed-source") {
     fatal_error("Simulation mode modified-fixed-source not yet implemented.");
   } else if (mode == "noise") {
-    fatal_error("Simulation mode noise not yet implemented.");
+    simulation = make_noise_simulator(sim);
   } else {
     fatal_error("Unknown simulation mode " + mode + ".");
   }

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -23,8 +23,8 @@
  *
  * */
 #include <simulation/fixed_source.hpp>
-#include <simulation/power_iterator.hpp>
 #include <simulation/noise.hpp>
+#include <simulation/power_iterator.hpp>
 #include <simulation/simulation.hpp>
 #include <utils/error.hpp>
 #include <utils/mpi.hpp>


### PR DESCRIPTION
This gets noise simulations working with the refactorizations that were previously made to incorporate different transport and collision operators. This now makes it possible to using different types of collision operators for the power iterations portions of neutron noise simulations.