### PR TITLE
Energy Dependent Cross Section Perturbations

### DIFF
--- a/include/noise_source/cylindrical_oscillation_noise_source.hpp
+++ b/include/noise_source/cylindrical_oscillation_noise_source.hpp
@@ -27,15 +27,17 @@
 
 #include <noise_source/oscillation_noise_source.hpp>
 #include <utils/position.hpp>
+#include <utils/tabulated_1d.hpp>
 
 #include <yaml-cpp/yaml.h>
 
 class CylindricalOscillationNoiseSource : public OscillationNoiseSource {
  public:
   CylindricalOscillationNoiseSource(Position origin, double len, double rad,
-                                    char ax, double eps_tot, double eps_fis,
-                                    double eps_sct, double angular_frequency,
-                                    double phase);
+                                    char ax, const pndl::Tabulated1D& eps_tot,
+                                    const pndl::Tabulated1D& eps_fis,
+                                    const pndl::Tabulated1D& eps_sct,
+                                    double angular_frequency, double phase);
 
   bool is_inside(const Position& r) const override final;
   std::complex<double> dEt(const Position& r, double E,
@@ -55,9 +57,9 @@ class CylindricalOscillationNoiseSource : public OscillationNoiseSource {
   double length_, radius_;
   char axis_;
   double w0_, phase_;
-  double eps_t_;
-  double eps_f_;
-  double eps_s_;
+  pndl::Tabulated1D eps_t_;
+  pndl::Tabulated1D eps_f_;
+  pndl::Tabulated1D eps_s_;
 };
 
 std::shared_ptr<OscillationNoiseSource>

--- a/include/noise_source/propagating_channel_oscillation_noise_source.hpp
+++ b/include/noise_source/propagating_channel_oscillation_noise_source.hpp
@@ -1,7 +1,7 @@
 #ifndef PROPAGATING_CHANNEL_OSCILLATION_NOISE_SOURCE_H
 #define PROPAGATING_CHANNEL_OSCILLATION_NOISE_SOURCE_H
-
 #include <noise_source/oscillation_noise_source.hpp>
+#include <utils/tabulated_1d.hpp>
 
 #include <yaml-cpp/yaml.h>
 
@@ -9,8 +9,9 @@ class PropagatingChannelOscillationNoiseSource : public OscillationNoiseSource {
  public:
   PropagatingChannelOscillationNoiseSource(Position low, Position hi,
                                            double radius, char axis,
-                                           double eps_tot, double eps_fis,
-                                           double eps_sct,
+                                           const pndl::Tabulated1D& eps_tot,
+                                           const pndl::Tabulated1D& eps_fis,
+                                           const pndl::Tabulated1D& eps_sct,
                                            double angular_frequency,
                                            double velocity, double phase);
 
@@ -33,9 +34,9 @@ class PropagatingChannelOscillationNoiseSource : public OscillationNoiseSource {
   double radius_;
   char axis_;
   double w0_, phase_, velocity_;
-  double eps_t_;
-  double eps_f_;
-  double eps_s_;
+  pndl::Tabulated1D eps_t_;
+  pndl::Tabulated1D eps_f_;
+  pndl::Tabulated1D eps_s_;
 
   double calc_center_line_radius(const Position& r) const;
   double calc_total_phase(const Position& r) const;

--- a/include/noise_source/square_oscillation_noise_source.hpp
+++ b/include/noise_source/square_oscillation_noise_source.hpp
@@ -27,13 +27,16 @@
 
 #include <noise_source/oscillation_noise_source.hpp>
 #include <utils/position.hpp>
+#include <utils/tabulated_1d.hpp>
 
 #include <yaml-cpp/yaml.h>
 
 class SquareOscillationNoiseSource : public OscillationNoiseSource {
  public:
-  SquareOscillationNoiseSource(Position low, Position hi, double eps_tot,
-                               double eps_fis, double eps_sct,
+  SquareOscillationNoiseSource(Position low, Position hi,
+                               const pndl::Tabulated1D& eps_tot,
+                               const pndl::Tabulated1D& eps_fis,
+                               const pndl::Tabulated1D& eps_sct,
                                double angular_frequency, double phase);
 
   bool is_inside(const Position& r) const override final;
@@ -52,9 +55,9 @@ class SquareOscillationNoiseSource : public OscillationNoiseSource {
  private:
   Position low_, hi_;
   double w0_, phase_;
-  double eps_t_;
-  double eps_f_;
-  double eps_s_;
+  pndl::Tabulated1D eps_t_;
+  pndl::Tabulated1D eps_f_;
+  pndl::Tabulated1D eps_s_;
 };
 
 std::shared_ptr<OscillationNoiseSource> make_square_oscillation_noise_source(

--- a/include/simulation/power_iterator.hpp
+++ b/include/simulation/power_iterator.hpp
@@ -54,6 +54,7 @@ class PowerIterator : public Simulation {
   void set_families(bool fams) { calc_families = fams; }
   void set_pair_distance(bool prdist) { pair_distance_sqrd = prdist; }
   void set_empty_entropy_bins(bool eeb) { empty_entropy_bins = eeb; }
+  void set_save_source(bool save_src) { save_source = save_src; }
   void set_in_source_file(const std::string& sf) { in_source_file_name = sf; }
   void add_source(std::shared_ptr<Source> src);
   void set_nparticles(std::size_t np) { nparticles = np; }
@@ -93,6 +94,7 @@ class PowerIterator : public Simulation {
   bool calc_families = false;
   bool pair_distance_sqrd = false;
   bool empty_entropy_bins = false;
+  bool save_source = false;
 
   void check_time(std::size_t gen);
 

--- a/include/utils/tabulated_1d.hpp
+++ b/include/utils/tabulated_1d.hpp
@@ -1,0 +1,36 @@
+/*
+ * Abeille Monte Carlo Code
+ * Copyright 2019-2023, Hunter Belanger
+ *
+ * hunter.belanger@gmail.com
+ *
+ * This file is part of the Abeille Monte Carlo code (Abeille).
+ *
+ * Abeille is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Abeille is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Abeille. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * */
+#ifndef TABULATED_1D_H
+#define TABULATED_1D_H
+
+#include <PapillonNDL/tabulated_1d.hpp>
+
+#include <yaml-cpp/yaml.h>
+
+#include <string>
+
+pndl::Tabulated1D make_tabulated_1d(const YAML::Node& node,
+                                    const std::string& x_name,
+                                    const std::string& y_name);
+
+#endif

--- a/input_files/noise_oscillation.yaml
+++ b/input_files/noise_oscillation.yaml
@@ -162,9 +162,15 @@ simulation:
       low: [2.1543, -2.8857, -2.00]
       hi: [2.8857, -2.1543, 2.00]
       angular-frequency: 6.28318531 # 2 pi
-      epsilon-total: 0.041
-      epsilon-fission: 0.021
-      epsilon-scatter: 0.034
+      epsilon-total:
+        energy: [0., 2.]
+        value: [0.041, 0.041]
+      epsilon-fission:
+        energy: [0., 2.]
+        value: [0.021, 0.021]
+      epsilon-scatter:
+        energy: [0., 2.]
+        value: [0.034, 0.034]
 
   entropy:
     low: [-10.71, -10.71, -2.00]

--- a/sourcelist.cmake
+++ b/sourcelist.cmake
@@ -66,6 +66,7 @@ set(ABEILLE_SOURCE_FILES ${ABEILLE_SOURCE_FILES}
   src/surface.cpp
   src/majorant.cpp
   src/pctable.cpp
+  src/tabulated_1d.cpp
   src/error.cpp
   src/mpi.cpp
   src/settings.cpp

--- a/src/cylindrical_oscillation_noise_source.cpp
+++ b/src/cylindrical_oscillation_noise_source.cpp
@@ -68,20 +68,20 @@ CylindricalOscillationNoiseSource::CylindricalOscillationNoiseSource(
 
   // Make sure epsilons are positive
   for (const auto et : eps_t_.y()) {
-    if (et <= 0.) {
-      fatal_error("Negative or zero epsilon total.");
+    if (et < 0.) {
+      fatal_error("Negative epsilon total.");
     }
   }
 
   for (const auto ef : eps_f_.y()) {
-    if (ef <= 0.) {
-      fatal_error("Negative or zero epsilon fission.");
+    if (ef < 0.) {
+      fatal_error("Negative epsilon fission.");
     }
   }
 
   for (const auto es : eps_s_.y()) {
-    if (es <= 0.) {
-      fatal_error("Negative or zero epsilon scatter.");
+    if (es < 0.) {
+      fatal_error("Negative epsilon scatter.");
     }
   }
 }
@@ -330,10 +330,9 @@ make_cylindrical_oscillation_noise_source(const YAML::Node& snode) {
   pndl::Tabulated1D eps_t =
       make_tabulated_1d(snode["epsilon-total"], "energy", "value");
   for (const auto et : eps_t.y()) {
-    if (et <= 0.) {
+    if (et < 0.) {
       fatal_error(
-          "Epsilon total can not be negative or zero for oscillation noise "
-          "source.");
+          "Epsilon total can not be negative for oscillation noise source.");
     }
   }
   if (eps_t.min_x() > settings::min_energy ||
@@ -349,10 +348,9 @@ make_cylindrical_oscillation_noise_source(const YAML::Node& snode) {
   pndl::Tabulated1D eps_f =
       make_tabulated_1d(snode["epsilon-fission"], "energy", "value");
   for (const auto ef : eps_f.y()) {
-    if (ef <= 0.) {
+    if (ef < 0.) {
       fatal_error(
-          "Epsilon fission can not be negative or zero for oscillation noise "
-          "source.");
+          "Epsilon fission can not be negative for oscillation noise source.");
     }
   }
   if (eps_f.min_x() > settings::min_energy ||
@@ -368,10 +366,9 @@ make_cylindrical_oscillation_noise_source(const YAML::Node& snode) {
   pndl::Tabulated1D eps_s =
       make_tabulated_1d(snode["epsilon-scatter"], "energy", "value");
   for (const auto es : eps_s.y()) {
-    if (es <= 0.) {
+    if (es < 0.) {
       fatal_error(
-          "Epsilon scatter can not be negative or zero for oscillation noise "
-          "source.");
+          "Epsilon scatter can not be negative for oscillation noise source.");
     }
   }
   if (eps_s.min_x() > settings::min_energy ||

--- a/src/cylindrical_oscillation_noise_source.cpp
+++ b/src/cylindrical_oscillation_noise_source.cpp
@@ -362,7 +362,7 @@ make_cylindrical_oscillation_noise_source(const YAML::Node& snode) {
         "energies.");
   }
 
-  if (!snode["epsilon-scatter"] || !snode["epsilon-scatter"].IsScalar()) {
+  if (!snode["epsilon-scatter"] || !snode["epsilon-scatter"].IsMap()) {
     fatal_error("No valid epsilon-scatter entry for oscillation noise source.");
   }
   pndl::Tabulated1D eps_s =

--- a/src/cylindrical_oscillation_noise_source.cpp
+++ b/src/cylindrical_oscillation_noise_source.cpp
@@ -28,12 +28,14 @@
 #include <utils/constants.hpp>
 #include <utils/direction.hpp>
 #include <utils/error.hpp>
+#include <utils/settings.hpp>
 
 #include <sstream>
 
 CylindricalOscillationNoiseSource::CylindricalOscillationNoiseSource(
-    Position origin, double len, double rad, char ax, double eps_tot,
-    double eps_fis, double eps_sct, double angular_frequency, double phase)
+    Position origin, double len, double rad, char ax,
+    const pndl::Tabulated1D& eps_tot, const pndl::Tabulated1D& eps_fis,
+    const pndl::Tabulated1D& eps_sct, double angular_frequency, double phase)
     : origin_(origin),
       length_(len),
       radius_(rad),
@@ -65,16 +67,22 @@ CylindricalOscillationNoiseSource::CylindricalOscillationNoiseSource(
   }
 
   // Make sure epsilons are positive
-  if (eps_t_ <= 0.) {
-    fatal_error("Negative or zero epsilon total.");
+  for (const auto et : eps_t_.y()) {
+    if (et <= 0.) {
+      fatal_error("Negative or zero epsilon total.");
+    }
   }
 
-  if (eps_f_ <= 0.) {
-    fatal_error("Negative or zero epsilon fission.");
+  for (const auto ef : eps_f_.y()) {
+    if (ef <= 0.) {
+      fatal_error("Negative or zero epsilon fission.");
+    }
   }
 
-  if (eps_s_ <= 0.) {
-    fatal_error("Negative or zero epsilon scatter.");
+  for (const auto es : eps_s_.y()) {
+    if (es <= 0.) {
+      fatal_error("Negative or zero epsilon scatter.");
+    }
   }
 }
 
@@ -150,10 +158,10 @@ std::complex<double> CylindricalOscillationNoiseSource::dEt(const Position& r,
   double err = (n * w0_ - w) / w;
 
   if (n == 1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_t_ * xs * PI) *
+    return std::complex<double>(0., -eps_t_(E) * xs * PI) *
            std::exp(std::complex<double>(0., phase_));
   } else if (n == -1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_t_ * xs * PI) *
+    return std::complex<double>(0., -eps_t_(E) * xs * PI) *
            std::exp(std::complex<double>(0., -phase_));
   } else {
     return {0., 0.};
@@ -161,17 +169,17 @@ std::complex<double> CylindricalOscillationNoiseSource::dEt(const Position& r,
 }
 
 std::complex<double> CylindricalOscillationNoiseSource::dEt_Et(
-    const Position& /*r*/, double /*E*/, double w) const {
+    const Position& /*r*/, double E, double w) const {
   // Get the frequency multiple n
   int32_t n = static_cast<int32_t>(std::round(w / w0_));
 
   double err = (n * w0_ - w) / w;
 
   if (n == 1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_t_ * PI) *
+    return std::complex<double>(0., -eps_t_(E) * PI) *
            std::exp(std::complex<double>(0., phase_));
   } else if (n == -1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_t_ * PI) *
+    return std::complex<double>(0., -eps_t_(E) * PI) *
            std::exp(std::complex<double>(0., -phase_));
   } else {
     return {0., 0.};
@@ -179,17 +187,17 @@ std::complex<double> CylindricalOscillationNoiseSource::dEt_Et(
 }
 
 std::complex<double> CylindricalOscillationNoiseSource::dEf_Ef(
-    const Position& /*r*/, double /*E*/, double w) const {
+    const Position& /*r*/, double E, double w) const {
   // Get the frequency multiple n
   int32_t n = static_cast<int32_t>(std::round(w / w0_));
 
   double err = (n * w0_ - w) / w;
 
   if (n == 1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_f_ * PI) *
+    return std::complex<double>(0., -eps_f_(E) * PI) *
            std::exp(std::complex<double>(0., phase_));
   } else if (n == -1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_f_ * PI) *
+    return std::complex<double>(0., -eps_f_(E) * PI) *
            std::exp(std::complex<double>(0., -phase_));
   } else {
     return {0., 0.};
@@ -197,17 +205,17 @@ std::complex<double> CylindricalOscillationNoiseSource::dEf_Ef(
 }
 
 std::complex<double> CylindricalOscillationNoiseSource::dEelastic_Eelastic(
-    const Position& /*r*/, double /*E*/, double w) const {
+    const Position& /*r*/, double E, double w) const {
   // Get the frequency multiple n
   int32_t n = static_cast<int32_t>(std::round(w / w0_));
 
   double err = (n * w0_ - w) / w;
 
   if (n == 1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_s_ * PI) *
+    return std::complex<double>(0., -eps_s_(E) * PI) *
            std::exp(std::complex<double>(0., phase_));
   } else if (n == -1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_s_ * PI) *
+    return std::complex<double>(0., -eps_s_(E) * PI) *
            std::exp(std::complex<double>(0., -phase_));
   } else {
     return {0., 0.};
@@ -215,17 +223,17 @@ std::complex<double> CylindricalOscillationNoiseSource::dEelastic_Eelastic(
 }
 
 std::complex<double> CylindricalOscillationNoiseSource::dEmt_Emt(
-    uint32_t /*mt*/, const Position& /*r*/, double /*E*/, double w) const {
+    uint32_t /*mt*/, const Position& /*r*/, double E, double w) const {
   // Get the frequency multiple n
   int32_t n = static_cast<int32_t>(std::round(w / w0_));
 
   double err = (n * w0_ - w) / w;
 
   if (n == 1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_s_ * PI) *
+    return std::complex<double>(0., -eps_s_(E) * PI) *
            std::exp(std::complex<double>(0., phase_));
   } else if (n == -1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_s_ * PI) *
+    return std::complex<double>(0., -eps_s_(E) * PI) *
            std::exp(std::complex<double>(0., -phase_));
   } else {
     return {0., 0.};
@@ -316,46 +324,61 @@ make_cylindrical_oscillation_noise_source(const YAML::Node& snode) {
   }
 
   // Get epsilons
-  if (!snode["epsilon-total"] || !snode["epsilon-total"].IsScalar()) {
+  if (!snode["epsilon-total"] || !snode["epsilon-total"].IsMap()) {
+    fatal_error("No valid epsilon-total entry for oscillation noise source.");
+  }
+  pndl::Tabulated1D eps_t =
+      make_tabulated_1d(snode["epsilon-total"], "energy", "value");
+  for (const auto et : eps_t.y()) {
+    if (et <= 0.) {
+      fatal_error(
+          "Epsilon total can not be negative or zero for oscillation noise "
+          "source.");
+    }
+  }
+  if (eps_t.min_x() > settings::min_energy ||
+      eps_t.max_x() < settings::max_energy) {
     fatal_error(
-        "No valid epsilon-total entry for cylindrical oscillation noise "
-        "source.");
+        "Epsilon total energies are smaller than min and max particle "
+        "energies.");
   }
 
-  double eps_t = snode["epsilon-total"].as<double>();
-
-  if (eps_t <= 0.) {
-    fatal_error(
-        "Epsilon total can not be negative or zero for cylindrical oscillation "
-        "noise source.");
+  if (!snode["epsilon-fission"] || !snode["epsilon-fission"].IsMap()) {
+    fatal_error("No valid epsilon-fission entry for oscillation noise source.");
   }
-
-  if (!snode["epsilon-fission"] || !snode["epsilon-fission"].IsScalar()) {
-    fatal_error(
-        "No valid epsilon-fission entry for cylindrical oscillation noise "
-        "source.");
+  pndl::Tabulated1D eps_f =
+      make_tabulated_1d(snode["epsilon-fission"], "energy", "value");
+  for (const auto ef : eps_f.y()) {
+    if (ef <= 0.) {
+      fatal_error(
+          "Epsilon fission can not be negative or zero for oscillation noise "
+          "source.");
+    }
   }
-
-  double eps_f = snode["epsilon-fission"].as<double>();
-
-  if (eps_f <= 0.) {
+  if (eps_f.min_x() > settings::min_energy ||
+      eps_f.max_x() < settings::max_energy) {
     fatal_error(
-        "Epsilon fission can not be negative or zero for cylindrical "
-        "oscillation noise source.");
+        "Epsilon fission energies are smaller than min and max particle "
+        "energies.");
   }
 
   if (!snode["epsilon-scatter"] || !snode["epsilon-scatter"].IsScalar()) {
-    fatal_error(
-        "No valid epsilon-scatter entry for cylindrical oscillation noise "
-        "source.");
+    fatal_error("No valid epsilon-scatter entry for oscillation noise source.");
   }
-
-  double eps_s = snode["epsilon-scatter"].as<double>();
-
-  if (eps_s <= 0.) {
+  pndl::Tabulated1D eps_s =
+      make_tabulated_1d(snode["epsilon-scatter"], "energy", "value");
+  for (const auto es : eps_s.y()) {
+    if (es <= 0.) {
+      fatal_error(
+          "Epsilon scatter can not be negative or zero for oscillation noise "
+          "source.");
+    }
+  }
+  if (eps_s.min_x() > settings::min_energy ||
+      eps_s.max_x() < settings::max_energy) {
     fatal_error(
-        "Epsilon scatter can not be negative or zero for cylindrical "
-        "oscillation noise source.");
+        "Epsilon scatter energies are smaller than min and max particle "
+        "energies.");
   }
 
   return std::make_shared<CylindricalOscillationNoiseSource>(

--- a/src/power_iterator.cpp
+++ b/src/power_iterator.cpp
@@ -418,7 +418,7 @@ void PowerIterator::run() {
 
   // Start timer
   simulation_timer.reset();
-  mpi::synchronize(); // Make sure everyone is here before starting the timer
+  mpi::synchronize();  // Make sure everyone is here before starting the timer
   simulation_timer.start();
 
   // Make sure we have room for the generation times
@@ -573,7 +573,7 @@ void PowerIterator::run() {
   write_entropy_families_etc_to_results();
 
   // write source
-  write_source(bank);
+  if (save_source) write_source(bank);
 }
 
 void PowerIterator::comb_particles(std::vector<BankedParticle>& next_gen) {
@@ -1046,6 +1046,14 @@ std::shared_ptr<PowerIterator> make_power_iterator(const YAML::Node& sim) {
     fatal_error("Invalid families entry in k-eigenvalue simulation.");
   }
 
+  // Save source
+  bool save_source = false;
+  if (sim["save-source"] && sim["save-source"].IsScalar()) {
+    families = sim["save-source"].as<bool>();
+  } else if (sim["save-source"]) {
+    fatal_error("Invalid save-source entry in k-eigenvalue simulation.");
+  }
+
   // Pair Distance Sqrd
   bool pair_dist = false;
   if (sim["pair-distance-sqrd"] && sim["pair-distance-sqrd"].IsScalar()) {
@@ -1097,6 +1105,7 @@ std::shared_ptr<PowerIterator> make_power_iterator(const YAML::Node& sim) {
   }
   simptr->set_combing(combing);
   simptr->set_families(families);
+  simptr->set_save_source(save_source);
   simptr->set_pair_distance(pair_dist);
   simptr->set_empty_entropy_bins(empty_entropy_frac);
   if (cancelator) simptr->set_cancelator(cancelator);

--- a/src/propagating_channel_oscillation_noise_source.cpp
+++ b/src/propagating_channel_oscillation_noise_source.cpp
@@ -59,20 +59,20 @@ PropagatingChannelOscillationNoiseSource::
 
   // Make sure epsilons are positive
   for (const auto et : eps_t_.y()) {
-    if (et <= 0.) {
-      fatal_error("Negative or zero epsilon total.");
+    if (et < 0.) {
+      fatal_error("Negative epsilon total.");
     }
   }
 
   for (const auto ef : eps_f_.y()) {
-    if (ef <= 0.) {
-      fatal_error("Negative or zero epsilon fission.");
+    if (ef < 0.) {
+      fatal_error("Negative epsilon fission.");
     }
   }
 
   for (const auto es : eps_s_.y()) {
-    if (es <= 0.) {
-      fatal_error("Negative or zero epsilon scatter.");
+    if (es < 0.) {
+      fatal_error("Negative epsilon scatter.");
     }
   }
 }
@@ -345,10 +345,9 @@ make_propagating_channel_oscillation_noise_source(const YAML::Node& snode) {
   pndl::Tabulated1D eps_t =
       make_tabulated_1d(snode["epsilon-total"], "energy", "value");
   for (const auto et : eps_t.y()) {
-    if (et <= 0.) {
+    if (et < 0.) {
       fatal_error(
-          "Epsilon total can not be negative or zero for oscillation noise "
-          "source.");
+          "Epsilon total can not be negative for oscillation noise source.");
     }
   }
   if (eps_t.min_x() > settings::min_energy ||
@@ -364,10 +363,9 @@ make_propagating_channel_oscillation_noise_source(const YAML::Node& snode) {
   pndl::Tabulated1D eps_f =
       make_tabulated_1d(snode["epsilon-fission"], "energy", "value");
   for (const auto ef : eps_f.y()) {
-    if (ef <= 0.) {
+    if (ef < 0.) {
       fatal_error(
-          "Epsilon fission can not be negative or zero for oscillation noise "
-          "source.");
+          "Epsilon fission can not be negative for oscillation noise source.");
     }
   }
   if (eps_f.min_x() > settings::min_energy ||
@@ -383,10 +381,9 @@ make_propagating_channel_oscillation_noise_source(const YAML::Node& snode) {
   pndl::Tabulated1D eps_s =
       make_tabulated_1d(snode["epsilon-scatter"], "energy", "value");
   for (const auto es : eps_s.y()) {
-    if (es <= 0.) {
+    if (es < 0.) {
       fatal_error(
-          "Epsilon scatter can not be negative or zero for oscillation noise "
-          "source.");
+          "Epsilon scatter can not be negative for oscillation noise source.");
     }
   }
   if (eps_s.min_x() > settings::min_energy ||

--- a/src/propagating_channel_oscillation_noise_source.cpp
+++ b/src/propagating_channel_oscillation_noise_source.cpp
@@ -377,7 +377,7 @@ make_propagating_channel_oscillation_noise_source(const YAML::Node& snode) {
         "energies.");
   }
 
-  if (!snode["epsilon-scatter"] || !snode["epsilon-scatter"].IsScalar()) {
+  if (!snode["epsilon-scatter"] || !snode["epsilon-scatter"].IsMap()) {
     fatal_error("No valid epsilon-scatter entry for oscillation noise source.");
   }
   pndl::Tabulated1D eps_s =

--- a/src/propagating_channel_oscillation_noise_source.cpp
+++ b/src/propagating_channel_oscillation_noise_source.cpp
@@ -5,6 +5,7 @@
 #include <utils/constants.hpp>
 #include <utils/direction.hpp>
 #include <utils/error.hpp>
+#include <utils/settings.hpp>
 
 #include <cmath>
 #include <sstream>
@@ -12,8 +13,9 @@
 PropagatingChannelOscillationNoiseSource::
     PropagatingChannelOscillationNoiseSource(Position low, Position hi,
                                              double radius, char axis,
-                                             double eps_tot, double eps_fis,
-                                             double eps_sct,
+                                             const pndl::Tabulated1D& eps_tot,
+                                             const pndl::Tabulated1D& eps_fis,
+                                             const pndl::Tabulated1D& eps_sct,
                                              double angular_frequency,
                                              double velocity, double phase)
     : low_(low),
@@ -56,16 +58,22 @@ PropagatingChannelOscillationNoiseSource::
   }
 
   // Make sure epsilons are positive
-  if (eps_t_ <= 0.) {
-    fatal_error("Negative or zero epsilon total.");
+  for (const auto et : eps_t_.y()) {
+    if (et <= 0.) {
+      fatal_error("Negative or zero epsilon total.");
+    }
   }
 
-  if (eps_f_ <= 0.) {
-    fatal_error("Negative or zero epsilon fission.");
+  for (const auto ef : eps_f_.y()) {
+    if (ef <= 0.) {
+      fatal_error("Negative or zero epsilon fission.");
+    }
   }
 
-  if (eps_s_ <= 0.) {
-    fatal_error("Negative or zero epsilon scatter.");
+  for (const auto es : eps_s_.y()) {
+    if (es <= 0.) {
+      fatal_error("Negative or zero epsilon scatter.");
+    }
   }
 }
 
@@ -109,10 +117,10 @@ std::complex<double> PropagatingChannelOscillationNoiseSource::dEt(
   const double tot_phase = calc_total_phase(r);
 
   if (n == 1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_t_ * xs * PI) *
+    return std::complex<double>(0., -eps_t_(E) * xs * PI) *
            std::exp(std::complex<double>(0., tot_phase));
   } else if (n == -1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_t_ * xs * PI) *
+    return std::complex<double>(0., -eps_t_(E) * xs * PI) *
            std::exp(std::complex<double>(0., -tot_phase));
   } else {
     return {0., 0.};
@@ -120,7 +128,7 @@ std::complex<double> PropagatingChannelOscillationNoiseSource::dEt(
 }
 
 std::complex<double> PropagatingChannelOscillationNoiseSource::dEt_Et(
-    const Position& r, double /*E*/, double w) const {
+    const Position& r, double E, double w) const {
   // Get the frequency multiple n
   int32_t n = static_cast<int32_t>(std::round(w / w0_));
 
@@ -129,10 +137,10 @@ std::complex<double> PropagatingChannelOscillationNoiseSource::dEt_Et(
   const double tot_phase = calc_total_phase(r);
 
   if (n == 1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_t_ * PI) *
+    return std::complex<double>(0., -eps_t_(E) * PI) *
            std::exp(std::complex<double>(0., tot_phase));
   } else if (n == -1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_t_ * PI) *
+    return std::complex<double>(0., -eps_t_(E) * PI) *
            std::exp(std::complex<double>(0., -tot_phase));
   } else {
     return {0., 0.};
@@ -140,7 +148,7 @@ std::complex<double> PropagatingChannelOscillationNoiseSource::dEt_Et(
 }
 
 std::complex<double> PropagatingChannelOscillationNoiseSource::dEf_Ef(
-    const Position& r, double /*E*/, double w) const {
+    const Position& r, double E, double w) const {
   // Get the frequency multiple n
   int32_t n = static_cast<int32_t>(std::round(w / w0_));
 
@@ -149,10 +157,10 @@ std::complex<double> PropagatingChannelOscillationNoiseSource::dEf_Ef(
   const double tot_phase = calc_total_phase(r);
 
   if (n == 1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_f_ * PI) *
+    return std::complex<double>(0., -eps_f_(E) * PI) *
            std::exp(std::complex<double>(0., tot_phase));
   } else if (n == -1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_f_ * PI) *
+    return std::complex<double>(0., -eps_f_(E) * PI) *
            std::exp(std::complex<double>(0., -tot_phase));
   } else {
     return {0., 0.};
@@ -161,7 +169,7 @@ std::complex<double> PropagatingChannelOscillationNoiseSource::dEf_Ef(
 
 std::complex<double>
 PropagatingChannelOscillationNoiseSource::dEelastic_Eelastic(const Position& r,
-                                                             double /*E*/,
+                                                             double E,
                                                              double w) const {
   // Get the frequency multiple n
   int32_t n = static_cast<int32_t>(std::round(w / w0_));
@@ -171,10 +179,10 @@ PropagatingChannelOscillationNoiseSource::dEelastic_Eelastic(const Position& r,
   const double tot_phase = calc_total_phase(r);
 
   if (n == 1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_s_ * PI) *
+    return std::complex<double>(0., -eps_s_(E) * PI) *
            std::exp(std::complex<double>(0., tot_phase));
   } else if (n == -1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_s_ * PI) *
+    return std::complex<double>(0., -eps_s_(E) * PI) *
            std::exp(std::complex<double>(0., -tot_phase));
   } else {
     return {0., 0.};
@@ -182,7 +190,7 @@ PropagatingChannelOscillationNoiseSource::dEelastic_Eelastic(const Position& r,
 }
 
 std::complex<double> PropagatingChannelOscillationNoiseSource::dEmt_Emt(
-    uint32_t /*mt*/, const Position& r, double /*E*/, double w) const {
+    uint32_t /*mt*/, const Position& r, double E, double w) const {
   // Get the frequency multiple n
   int32_t n = static_cast<int32_t>(std::round(w / w0_));
 
@@ -191,10 +199,10 @@ std::complex<double> PropagatingChannelOscillationNoiseSource::dEmt_Emt(
   const double tot_phase = calc_total_phase(r);
 
   if (n == 1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_s_ * PI) *
+    return std::complex<double>(0., -eps_s_(E) * PI) *
            std::exp(std::complex<double>(0., tot_phase));
   } else if (n == -1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_s_ * PI) *
+    return std::complex<double>(0., -eps_s_(E) * PI) *
            std::exp(std::complex<double>(0., -tot_phase));
   } else {
     return {0., 0.};
@@ -331,46 +339,61 @@ make_propagating_channel_oscillation_noise_source(const YAML::Node& snode) {
   }
 
   // Get epsilons
-  if (!snode["epsilon-total"] || !snode["epsilon-total"].IsScalar()) {
+  if (!snode["epsilon-total"] || !snode["epsilon-total"].IsMap()) {
+    fatal_error("No valid epsilon-total entry for oscillation noise source.");
+  }
+  pndl::Tabulated1D eps_t =
+      make_tabulated_1d(snode["epsilon-total"], "energy", "value");
+  for (const auto et : eps_t.y()) {
+    if (et <= 0.) {
+      fatal_error(
+          "Epsilon total can not be negative or zero for oscillation noise "
+          "source.");
+    }
+  }
+  if (eps_t.min_x() > settings::min_energy ||
+      eps_t.max_x() < settings::max_energy) {
     fatal_error(
-        "No valid epsilon-total entry for propagating channel oscillation "
-        "noise source.");
+        "Epsilon total energies are smaller than min and max particle "
+        "energies.");
   }
 
-  double eps_t = snode["epsilon-total"].as<double>();
-
-  if (eps_t <= 0.) {
-    fatal_error(
-        "Epsilon total can not be negative or zero for propagating channel "
-        "oscillation noise source.");
+  if (!snode["epsilon-fission"] || !snode["epsilon-fission"].IsMap()) {
+    fatal_error("No valid epsilon-fission entry for oscillation noise source.");
   }
-
-  if (!snode["epsilon-fission"] || !snode["epsilon-fission"].IsScalar()) {
-    fatal_error(
-        "No valid epsilon-fission entry for propagating channel oscillation "
-        "noise source.");
+  pndl::Tabulated1D eps_f =
+      make_tabulated_1d(snode["epsilon-fission"], "energy", "value");
+  for (const auto ef : eps_f.y()) {
+    if (ef <= 0.) {
+      fatal_error(
+          "Epsilon fission can not be negative or zero for oscillation noise "
+          "source.");
+    }
   }
-
-  double eps_f = snode["epsilon-fission"].as<double>();
-
-  if (eps_f <= 0.) {
+  if (eps_f.min_x() > settings::min_energy ||
+      eps_f.max_x() < settings::max_energy) {
     fatal_error(
-        "Epsilon fission can not be negative or zero for propagating channel "
-        "oscillation noise source.");
+        "Epsilon fission energies are smaller than min and max particle "
+        "energies.");
   }
 
   if (!snode["epsilon-scatter"] || !snode["epsilon-scatter"].IsScalar()) {
-    fatal_error(
-        "No valid epsilon-scatter entry for propagating channel oscillation "
-        "noise source.");
+    fatal_error("No valid epsilon-scatter entry for oscillation noise source.");
   }
-
-  double eps_s = snode["epsilon-scatter"].as<double>();
-
-  if (eps_s <= 0.) {
+  pndl::Tabulated1D eps_s =
+      make_tabulated_1d(snode["epsilon-scatter"], "energy", "value");
+  for (const auto es : eps_s.y()) {
+    if (es <= 0.) {
+      fatal_error(
+          "Epsilon scatter can not be negative or zero for oscillation noise "
+          "source.");
+    }
+  }
+  if (eps_s.min_x() > settings::min_energy ||
+      eps_s.max_x() < settings::max_energy) {
     fatal_error(
-        "Epsilon scatter can not be negative or zero for propagating channel "
-        "oscillation noise source.");
+        "Epsilon scatter energies are smaller than min and max particle "
+        "energies.");
   }
 
   return std::make_shared<PropagatingChannelOscillationNoiseSource>(

--- a/src/square_oscillation_noise_source.cpp
+++ b/src/square_oscillation_noise_source.cpp
@@ -56,20 +56,20 @@ SquareOscillationNoiseSource::SquareOscillationNoiseSource(
 
   // Make sure epsilons are positive
   for (const auto et : eps_t_.y()) {
-    if (et <= 0.) {
-      fatal_error("Negative or zero epsilon total.");
+    if (et < 0.) {
+      fatal_error("Negative epsilon total.");
     }
   }
 
   for (const auto ef : eps_f_.y()) {
-    if (ef <= 0.) {
-      fatal_error("Negative or zero epsilon fission.");
+    if (ef < 0.) {
+      fatal_error("Negative epsilon fission.");
     }
   }
 
   for (const auto es : eps_s_.y()) {
-    if (es <= 0.) {
-      fatal_error("Negative or zero epsilon scatter.");
+    if (es < 0.) {
+      fatal_error("Negative epsilon scatter.");
     }
   }
 }
@@ -245,10 +245,9 @@ std::shared_ptr<OscillationNoiseSource> make_square_oscillation_noise_source(
   pndl::Tabulated1D eps_t =
       make_tabulated_1d(snode["epsilon-total"], "energy", "value");
   for (const auto et : eps_t.y()) {
-    if (et <= 0.) {
+    if (et < 0.) {
       fatal_error(
-          "Epsilon total can not be negative or zero for oscillation noise "
-          "source.");
+          "Epsilon total can not be negative for oscillation noise source.");
     }
   }
   if (eps_t.min_x() > settings::min_energy ||
@@ -264,10 +263,9 @@ std::shared_ptr<OscillationNoiseSource> make_square_oscillation_noise_source(
   pndl::Tabulated1D eps_f =
       make_tabulated_1d(snode["epsilon-fission"], "energy", "value");
   for (const auto ef : eps_f.y()) {
-    if (ef <= 0.) {
+    if (ef < 0.) {
       fatal_error(
-          "Epsilon fission can not be negative or zero for oscillation noise "
-          "source.");
+          "Epsilon fission can not be negative for oscillation noise source.");
     }
   }
   if (eps_f.min_x() > settings::min_energy ||
@@ -283,10 +281,9 @@ std::shared_ptr<OscillationNoiseSource> make_square_oscillation_noise_source(
   pndl::Tabulated1D eps_s =
       make_tabulated_1d(snode["epsilon-scatter"], "energy", "value");
   for (const auto es : eps_s.y()) {
-    if (es <= 0.) {
+    if (es < 0.) {
       fatal_error(
-          "Epsilon scatter can not be negative or zero for oscillation noise "
-          "source.");
+          "Epsilon scatter can not be negative for oscillation noise source.");
     }
   }
   if (eps_s.min_x() > settings::min_energy ||

--- a/src/square_oscillation_noise_source.cpp
+++ b/src/square_oscillation_noise_source.cpp
@@ -28,11 +28,13 @@
 #include <utils/constants.hpp>
 #include <utils/direction.hpp>
 #include <utils/error.hpp>
+#include <utils/settings.hpp>
 
 #include <sstream>
 
 SquareOscillationNoiseSource::SquareOscillationNoiseSource(
-    Position low, Position hi, double eps_tot, double eps_fis, double eps_sct,
+    Position low, Position hi, const pndl::Tabulated1D& eps_tot,
+    const pndl::Tabulated1D& eps_fis, const pndl::Tabulated1D& eps_sct,
     double angular_frequency, double phase)
     : low_(low),
       hi_(hi),
@@ -53,16 +55,22 @@ SquareOscillationNoiseSource::SquareOscillationNoiseSource(
   }
 
   // Make sure epsilons are positive
-  if (eps_t_ <= 0.) {
-    fatal_error("Negative or zero epsilon total.");
+  for (const auto et : eps_t_.y()) {
+    if (et <= 0.) {
+      fatal_error("Negative or zero epsilon total.");
+    }
   }
 
-  if (eps_f_ <= 0.) {
-    fatal_error("Negative or zero epsilon fission.");
+  for (const auto ef : eps_f_.y()) {
+    if (ef <= 0.) {
+      fatal_error("Negative or zero epsilon fission.");
+    }
   }
 
-  if (eps_s_ <= 0.) {
-    fatal_error("Negative or zero epsilon scatter.");
+  for (const auto es : eps_s_.y()) {
+    if (es <= 0.) {
+      fatal_error("Negative or zero epsilon scatter.");
+    }
   }
 }
 
@@ -98,10 +106,10 @@ std::complex<double> SquareOscillationNoiseSource::dEt(const Position& r,
   double err = (n * w0_ - w) / w;
 
   if (n == 1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_t_ * xs * PI) *
+    return std::complex<double>(0., -eps_t_(E) * xs * PI) *
            std::exp(std::complex<double>(0., phase_));
   } else if (n == -1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_t_ * xs * PI) *
+    return std::complex<double>(0., -eps_t_(E) * xs * PI) *
            std::exp(std::complex<double>(0., -phase_));
   } else {
     return {0., 0.};
@@ -109,7 +117,7 @@ std::complex<double> SquareOscillationNoiseSource::dEt(const Position& r,
 }
 
 std::complex<double> SquareOscillationNoiseSource::dEt_Et(const Position& /*r*/,
-                                                          double /*E*/,
+                                                          double E,
                                                           double w) const {
   // Get the frequency multiple n
   int32_t n = static_cast<int32_t>(std::round(w / w0_));
@@ -117,10 +125,10 @@ std::complex<double> SquareOscillationNoiseSource::dEt_Et(const Position& /*r*/,
   double err = (n * w0_ - w) / w;
 
   if (n == 1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_t_ * PI) *
+    return std::complex<double>(0., -eps_t_(E) * PI) *
            std::exp(std::complex<double>(0., phase_));
   } else if (n == -1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_t_ * PI) *
+    return std::complex<double>(0., -eps_t_(E) * PI) *
            std::exp(std::complex<double>(0., -phase_));
   } else {
     return {0., 0.};
@@ -128,7 +136,7 @@ std::complex<double> SquareOscillationNoiseSource::dEt_Et(const Position& /*r*/,
 }
 
 std::complex<double> SquareOscillationNoiseSource::dEf_Ef(const Position& /*r*/,
-                                                          double /*E*/,
+                                                          double E,
                                                           double w) const {
   // Get the frequency multiple n
   int32_t n = static_cast<int32_t>(std::round(w / w0_));
@@ -136,10 +144,10 @@ std::complex<double> SquareOscillationNoiseSource::dEf_Ef(const Position& /*r*/,
   double err = (n * w0_ - w) / w;
 
   if (n == 1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_f_ * PI) *
+    return std::complex<double>(0., -eps_f_(E) * PI) *
            std::exp(std::complex<double>(0., phase_));
   } else if (n == -1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_f_ * PI) *
+    return std::complex<double>(0., -eps_f_(E) * PI) *
            std::exp(std::complex<double>(0., -phase_));
   } else {
     return {0., 0.};
@@ -147,17 +155,17 @@ std::complex<double> SquareOscillationNoiseSource::dEf_Ef(const Position& /*r*/,
 }
 
 std::complex<double> SquareOscillationNoiseSource::dEelastic_Eelastic(
-    const Position& /*r*/, double /*E*/, double w) const {
+    const Position& /*r*/, double E, double w) const {
   // Get the frequency multiple n
   int32_t n = static_cast<int32_t>(std::round(w / w0_));
 
   double err = (n * w0_ - w) / w;
 
   if (n == 1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_s_ * PI) *
+    return std::complex<double>(0., -eps_s_(E) * PI) *
            std::exp(std::complex<double>(0., phase_));
   } else if (n == -1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_s_ * PI) *
+    return std::complex<double>(0., -eps_s_(E) * PI) *
            std::exp(std::complex<double>(0., -phase_));
   } else {
     return {0., 0.};
@@ -165,17 +173,17 @@ std::complex<double> SquareOscillationNoiseSource::dEelastic_Eelastic(
 }
 
 std::complex<double> SquareOscillationNoiseSource::dEmt_Emt(
-    uint32_t /*mt*/, const Position& /*r*/, double /*E*/, double w) const {
+    uint32_t /*mt*/, const Position& /*r*/, double E, double w) const {
   // Get the frequency multiple n
   int32_t n = static_cast<int32_t>(std::round(w / w0_));
 
   double err = (n * w0_ - w) / w;
 
   if (n == 1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_s_ * PI) *
+    return std::complex<double>(0., -eps_s_(E) * PI) *
            std::exp(std::complex<double>(0., phase_));
   } else if (n == -1 && std::abs(err) < 0.01) {
-    return std::complex<double>(0., -eps_s_ * PI) *
+    return std::complex<double>(0., -eps_s_(E) * PI) *
            std::exp(std::complex<double>(0., -phase_));
   } else {
     return {0., 0.};
@@ -231,43 +239,61 @@ std::shared_ptr<OscillationNoiseSource> make_square_oscillation_noise_source(
   }
 
   // Get epsilons
-  if (!snode["epsilon-total"] || !snode["epsilon-total"].IsScalar()) {
+  if (!snode["epsilon-total"] || !snode["epsilon-total"].IsMap()) {
+    fatal_error("No valid epsilon-total entry for oscillation noise source.");
+  }
+  pndl::Tabulated1D eps_t =
+      make_tabulated_1d(snode["epsilon-total"], "energy", "value");
+  for (const auto et : eps_t.y()) {
+    if (et <= 0.) {
+      fatal_error(
+          "Epsilon total can not be negative or zero for oscillation noise "
+          "source.");
+    }
+  }
+  if (eps_t.min_x() > settings::min_energy ||
+      eps_t.max_x() < settings::max_energy) {
     fatal_error(
-        "No valid epsilon-total entry for square oscillation noise source.");
+        "Epsilon total energies are smaller than min and max particle "
+        "energies.");
   }
 
-  double eps_t = snode["epsilon-total"].as<double>();
-
-  if (eps_t <= 0.) {
-    fatal_error(
-        "Epsilon total can not be negative or zero for square oscillation "
-        "noise source.");
+  if (!snode["epsilon-fission"] || !snode["epsilon-fission"].IsMap()) {
+    fatal_error("No valid epsilon-fission entry for oscillation noise source.");
   }
-
-  if (!snode["epsilon-fission"] || !snode["epsilon-fission"].IsScalar()) {
-    fatal_error(
-        "No valid epsilon-fission entry for square oscillation noise source.");
+  pndl::Tabulated1D eps_f =
+      make_tabulated_1d(snode["epsilon-fission"], "energy", "value");
+  for (const auto ef : eps_f.y()) {
+    if (ef <= 0.) {
+      fatal_error(
+          "Epsilon fission can not be negative or zero for oscillation noise "
+          "source.");
+    }
   }
-
-  double eps_f = snode["epsilon-fission"].as<double>();
-
-  if (eps_f <= 0.) {
+  if (eps_f.min_x() > settings::min_energy ||
+      eps_f.max_x() < settings::max_energy) {
     fatal_error(
-        "Epsilon fission can not be negative or zero for square oscillation "
-        "noise source.");
+        "Epsilon fission energies are smaller than min and max particle "
+        "energies.");
   }
 
   if (!snode["epsilon-scatter"] || !snode["epsilon-scatter"].IsScalar()) {
-    fatal_error(
-        "No valid epsilon-scatter entry for square oscillation noise source.");
+    fatal_error("No valid epsilon-scatter entry for oscillation noise source.");
   }
-
-  double eps_s = snode["epsilon-scatter"].as<double>();
-
-  if (eps_s <= 0.) {
+  pndl::Tabulated1D eps_s =
+      make_tabulated_1d(snode["epsilon-scatter"], "energy", "value");
+  for (const auto es : eps_s.y()) {
+    if (es <= 0.) {
+      fatal_error(
+          "Epsilon scatter can not be negative or zero for oscillation noise "
+          "source.");
+    }
+  }
+  if (eps_s.min_x() > settings::min_energy ||
+      eps_s.max_x() < settings::max_energy) {
     fatal_error(
-        "Epsilon scatter can not be negative or zero for square oscillation "
-        "noise source.");
+        "Epsilon scatter energies are smaller than min and max particle "
+        "energies.");
   }
 
   return std::make_shared<SquareOscillationNoiseSource>(

--- a/src/square_oscillation_noise_source.cpp
+++ b/src/square_oscillation_noise_source.cpp
@@ -277,7 +277,7 @@ std::shared_ptr<OscillationNoiseSource> make_square_oscillation_noise_source(
         "energies.");
   }
 
-  if (!snode["epsilon-scatter"] || !snode["epsilon-scatter"].IsScalar()) {
+  if (!snode["epsilon-scatter"] || !snode["epsilon-scatter"].IsMap()) {
     fatal_error("No valid epsilon-scatter entry for oscillation noise source.");
   }
   pndl::Tabulated1D eps_s =

--- a/src/tabulated_1d.cpp
+++ b/src/tabulated_1d.cpp
@@ -1,0 +1,59 @@
+/*
+ * Abeille Monte Carlo Code
+ * Copyright 2019-2023, Hunter Belanger
+ * Copyright 2021-2022, Commissariat à l'Energie Atomique et aux Energies
+ * Alternatives
+ *
+ * hunter.belanger@gmail.com
+ *
+ * This file is part of the Abeille Monte Carlo code (Abeille).
+ *
+ * Abeille is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Abeille is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Abeille. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * */
+#include <utils/error.hpp>
+#include <utils/tabulated_1d.hpp>
+
+#include <sstream>
+#include <vector>
+
+pndl::Tabulated1D make_tabulated_1d(const YAML::Node& node,
+                                    const std::string& x_name,
+                                    const std::string& y_name) {
+  if (!node[x_name] || node[x_name].IsSequence() == false) {
+    std::stringstream mssg;
+    mssg << "Function node does not have a valid x-axis entry by name of \""
+         << x_name << "\".";
+    fatal_error(mssg.str());
+  }
+
+  std::vector<double> x_vals = node[x_name].as<std::vector<double>>();
+  if (x_vals.size() < 2) {
+    fatal_error("Must have at least 2 tabulated points for function.");
+  }
+
+  if (!node[y_name] || node[y_name].IsSequence() == false) {
+    std::stringstream mssg;
+    mssg << "Function node does not have a valid y-axis entry by name of \""
+         << y_name << "\".";
+    fatal_error(mssg.str());
+  }
+
+  std::vector<double> y_vals = node[y_name].as<std::vector<double>>();
+  if (y_vals.size() != x_vals.size()) {
+    fatal_error("Different number of x and y values.");
+  }
+
+  return pndl::Tabulated1D(pndl::Interpolation::LinLin, x_vals, y_vals);
+}


### PR DESCRIPTION
This PR adds support for having cross section perturbations (such as oscillations or material vibrations) where the magnitude of reaction channel cross section perturbations is energy dependent. It also adds a new type of perturbation such as traveling cross section oscillations along the moderator in a fuel pin channel.